### PR TITLE
Refactor to accommodate stride manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ var shape = mat.shape;
 // returns [...]
 ```
 
+<a name="matrix-offset"></a>
+#### offset
+
+A property return the `offset` used to index into the underlying data store.
+
+``` javascript
+var offset = mat.offset;
+// returns 0
+```
+
+By default, the `offset` is `0`. While not __read-only__, most consumers should treat the `offset` as a __ready-only__ property.
+
+
 <a name="matrix-strides" class="read-only-property"></a>
 #### strides
 
@@ -145,6 +158,9 @@ A __read-only__ property returning the `strides` used to index into the underlyi
 var strides = mat.strides;
 // returns [...]
 ```
+
+While not __frozen__, most consumers should treat the `strides` elements as __read-only__ elements.
+
 
 <a name="matrix-length" class="read-only-property"></a>
 #### length
@@ -639,9 +655,9 @@ for ( i = 0; i < rows.length; i++ ) {
 A `Matrix` has a constructor having the following interface...
 
 
-#### mat.constructor( data, shape, dtype )
+#### mat.constructor( data, dtype, shape, offset, strides )
 
-Creates a new `Matrix` having a specified `shape`, `dtype`, and underlying typed `data` store.
+Creates a new `Matrix` having a specified `shape`, `offset`, `strides`, `dtype`, and underlying typed `data` store.
 
 ``` javascript
 var data = new Float32Array( 10 );
@@ -655,7 +671,7 @@ var mat1 = matrix( data, [5,2] );
 	  0 0 ]
 */
 
-var mat2 = new mat1.constructor( data, [2,5], 'float32' );
+var mat2 = new mat1.constructor( data, mat1.dtype, [2,5], 0, [5,1] );
 /*
 	[ 0 0 0 0 0
 	  0 0 0 0 0 ]

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ var shape = mat.shape;
 <a name="matrix-offset"></a>
 #### offset
 
-A property return the `offset` used to index into the underlying data store.
+A property returning the `offset` used to index into the underlying data store.
 
 ``` javascript
 var offset = mat.offset;

--- a/benchmark/b.create.js
+++ b/benchmark/b.create.js
@@ -98,7 +98,7 @@ res[ 3 ] = stop[ 0 ] + stop[ 1 ]*1e-9;
 // [4] Base matrix constructor:
 start = process.hrtime();
 for ( i = 0; i < len; i++ ) {
-	m = new m.constructor( iArr, [nRows,nCols], 'float32' );
+	m = new m.constructor( iArr, 'float32', [nRows,nCols], 0, [nCols,1]  );
 }
 stop = process.hrtime( start );
 
@@ -128,7 +128,7 @@ res[ 6 ] = stop[ 0 ] + stop[ 1 ]*1e-9;
 // [7] Raw matrix constructor:
 start = process.hrtime();
 for ( i = 0; i < len; i++ ) {
-	m = new m.constructor( iArr, [nRows,nCols], 'float32' );
+	m = new m.constructor( iArr, 'float32', [nRows,nCols], 0, [nCols,1] );
 }
 stop = process.hrtime( start );
 

--- a/lib/ctor.js
+++ b/lib/ctor.js
@@ -8,28 +8,16 @@
 *
 * @constructor
 * @param {Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} data - input typed array
-* @param {Number[]} shape - matrix dimensions/shape
 * @param {String} dtype - matrix data type
+* @param {Number[]} shape - matrix dimensions/shape
+* @param {Number} offset - matrix offset
+* @param {Number[]} strides - matrix strides
 * @returns {Matrix} Matrix instance
 */
-function Matrix( data, shape, dtype ) {
-	var strides,
-		ndims,
-		s, i;
-
+function Matrix( data, dtype, shape, offset, strides ) {
 	if ( !( this instanceof Matrix ) ) {
-		return new Matrix( data, shape, dtype );
+		return new Matrix( data, dtype, shape, offset, strides );
 	}
-	ndims = shape.length;
-
-	// Determine the matrix strides...
-	strides = new Array( ndims );
-	s = 1;
-	for ( i = ndims-1; i >= 0; i-- ) {
-		strides[ i ] = s;
-		s *= shape[ i ];
-	}
-
 	// Underlying data type:
 	Object.defineProperty( this, 'dtype', {
 		'value': dtype,
@@ -46,7 +34,7 @@ function Matrix( data, shape, dtype ) {
 		'writable': false
 	});
 
-	// Matrix strides (non-enumerable):
+	// Matrix strides:
 	Object.defineProperty( this, 'strides', {
 		'value': strides,
 		'configurable': false,
@@ -54,9 +42,17 @@ function Matrix( data, shape, dtype ) {
 		'writable': false
 	});
 
+	// Matrix offset:
+	Object.defineProperty( this, 'offset', {
+		'value': offset,
+		'configurable': false,
+		'enumerable': true,
+		'writable': true
+	});
+
 	// Number of matrix dimensions:
 	Object.defineProperty( this, 'ndims', {
-		'value': ndims,
+		'value': shape.length,
 		'configurable': false,
 		'enumerable': true,
 		'writable': false

--- a/lib/ctor.raw.js
+++ b/lib/ctor.raw.js
@@ -8,36 +8,24 @@
 *
 * @constructor
 * @param {Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array} data - input typed array
-* @param {Number[]} shape - matrix dimensions/shape
 * @param {String} dtype - matrix data type
+* @param {Number[]} shape - matrix dimensions/shape
+* @param {Number} offset - matrix offset
+* @param {Number[]} strides - matrix strides
 * @returns {Matrix} Matrix instance
 */
-function Matrix( data, shape, dtype ) {
-	var strides,
-		ndims,
-		s, i;
-
+function Matrix( data, dtype, shape, offset, strides ) {
 	if ( !( this instanceof Matrix ) ) {
-		return new Matrix( data, shape, dtype );
+		return new Matrix( data, dtype, shape, offset, strides );
 	}
-	ndims = shape.length;
-
-	// Determine the matrix strides...
-	strides = new Array( ndims );
-	s = 1;
-	for ( i = ndims-1; i >= 0; i-- ) {
-		strides[ i ] = s;
-		s *= shape[ i ];
-	}
-
 	this.dtype = dtype;
 	this.shape = shape;
 	this.strides = strides;
-	this.ndims = ndims;
+	this.offset = offset;
+	this.ndims = shape.length;
 	this.length = data.length;
 	this.nbytes = data.byteLength;
 	this.data = data;
-
 	return this;
 } // end FUNCTION Matrix()
 

--- a/lib/get.js
+++ b/lib/get.js
@@ -20,7 +20,7 @@ function get( i, j ) {
 	if ( !isNonNegativeInteger( i ) || !isNonNegativeInteger( j ) ) {
 		throw new TypeError( 'get()::invalid input argument. Indices must be nonnegative integers. Values: `[' + i + ','+ j + ']`.' );
 	}
-	return this.data[ i*this.strides[0] + j*this.strides[1] ];
+	return this.data[ this.offset + i*this.strides[0] + j*this.strides[1] ];
 } // end FUNCTION get()
 
 

--- a/lib/get.raw.js
+++ b/lib/get.raw.js
@@ -10,7 +10,7 @@
 */
 function get( i, j ) {
 	/*jshint validthis:true */
-	return this.data[ i*this.strides[0] + j*this.strides[1] ];
+	return this.data[ this.offset + i*this.strides[0] + j*this.strides[1] ];
 } // end FUNCTION get()
 
 

--- a/lib/iget.js
+++ b/lib/iget.js
@@ -16,13 +16,22 @@ var isInteger = require( 'validate.io-integer-primitive' );
 */
 function iget( idx ) {
 	/*jshint validthis:true */
+	var r, j;
 	if ( !isInteger( idx ) ) {
 		throw new TypeError( 'iget()::invalid input argument. Must provide a integer. Value: `' + idx + '`.' );
 	}
 	if ( idx < 0 ) {
 		idx += this.length;
+		if ( idx < 0 ) {
+			return;
+		}
 	}
-	return this.data[ idx ];
+	j = idx % this.strides[ 0 ];
+	r = idx - j;
+	if ( this.strides[ 0 ] < 0 ) {
+		r = -r;
+	}
+	return this.data[ this.offset + r + j*this.strides[1] ];
 } // end FUNCTION iget()
 
 

--- a/lib/iget.raw.js
+++ b/lib/iget.raw.js
@@ -9,10 +9,19 @@
 */
 function iget( idx ) {
 	/*jshint validthis:true */
+	var r, j;
 	if ( idx < 0 ) {
 		idx += this.length;
+		if ( idx < 0 ) {
+			return;
+		}
 	}
-	return this.data[ idx ];
+	j = idx % this.strides[ 0 ];
+	r = idx - j;
+	if ( this.strides[ 0 ] < 0 ) {
+		r = -r;
+	}
+	return this.data[ this.offset + r + j*this.strides[1] ];
 } // end FUNCTION iget()
 
 

--- a/lib/iset.js
+++ b/lib/iset.js
@@ -18,6 +18,7 @@ var isInteger = require( 'validate.io-integer-primitive' ),
 */
 function iset( idx, v ) {
 	/* jshint validthis: true */
+	var r, j;
 	if ( !isInteger( idx ) ) {
 		throw new TypeError( 'iset()::invalid input argument. An index must be an integer. Value: `' + idx + '`.' );
 	}
@@ -30,7 +31,12 @@ function iset( idx, v ) {
 			return this;
 		}
 	}
-	this.data[ idx ] = v;
+	j = idx % this.strides[ 0 ];
+	r = idx - j;
+	if ( this.strides[ 0 ] < 0 ) {
+		r = -r;
+	}
+	this.data[ this.offset + r + j*this.strides[1] ] = v;
 	return this;
 } // end FUNCTION iset()
 

--- a/lib/iset.raw.js
+++ b/lib/iset.raw.js
@@ -10,13 +10,19 @@
 */
 function iset( idx, v ) {
 	/* jshint validthis: true */
+	var r, j;
 	if ( idx < 0 ) {
 		idx += this.length;
 		if ( idx < 0 ) {
 			return this;
 		}
 	}
-	this.data[ idx ] = v;
+	j = idx % this.strides[ 0 ];
+	r = idx - j;
+	if ( this.strides[ 0 ] < 0 ) {
+		r = -r;
+	}
+	this.data[ this.offset + r + j*this.strides[1] ] = v;
 	return this;
 } // end FUNCTION iset()
 

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -100,7 +100,7 @@ function matrix() {
 		data = new BTYPES[ dtype ]( len );
 	}
 	// Return a new Matrix instance:
-	return new Matrix( data, shape, dtype );
+	return new Matrix( data, dtype, shape, 0, [shape[1],1] );
 } // end FUNCTION matrix()
 
 

--- a/lib/matrix.raw.js
+++ b/lib/matrix.raw.js
@@ -77,7 +77,7 @@ function matrix() {
 		data = new BTYPES[ dtype ]( len );
 	}
 	// Return a new Matrix instance:
-	return new Matrix( data, shape, dtype );
+	return new Matrix( data, dtype, shape, 0, [shape[1],1] );
 } // end FUNCTION matrix()
 
 

--- a/lib/mget.js
+++ b/lib/mget.js
@@ -25,10 +25,16 @@ function mget( rows, cols ) {
 	var nRows,
 		nCols,
 		out,
+		sgn,
 		d,
 		s0, s1, s2, s3,
+		o,
 		r, dr,
 		i, j, m, n;
+
+	s0 = this.strides[ 0 ];
+	s1 = this.strides[ 1 ];
+	o = this.offset;
 
 	if ( arguments.length < 2 ) {
 		if ( !isNonNegativeIntegerArray( rows ) ) {
@@ -41,14 +47,17 @@ function mget( rows, cols ) {
 				i.push( rows[ n ] );
 			}
 		}
-		j = i.length;
+		m = i.length;
 
 		// Create a row vector (matrix):
-		d = new BTYPES[ this.dtype ]( j );
-		out = new this.constructor( d, [1,j], this.dtype );
+		d = new BTYPES[ this.dtype ]( m );
+		out = new this.constructor( d, this.dtype, [1,m], 0, [m,1] );
 
-		for ( n = 0; n < j; n++ ) {
-			d[ n ] = this.data[ i[n] ];
+		sgn = ( s0 < 0 ) ? -1 : 1;
+		for ( n = 0; n < m; n++ ) {
+			j = i[ n ] % s0;
+			r = sgn * ( i[n] - j );
+			d[ n ] = this.data[ o + r + j*s1 ];
 		}
 	} else {
 		nRows = this.shape[ 0 ];
@@ -92,14 +101,12 @@ function mget( rows, cols ) {
 		nCols = j.length;
 
 		d = new BTYPES[ this.dtype ]( nRows*nCols );
-		out = new this.constructor( d, [nRows,nCols], this.dtype );
+		out = new this.constructor( d, this.dtype, [nRows,nCols], 0, [nCols,1]);
 
-		s0 = this.strides[ 0 ];
-		s1 = this.strides[ 1 ];
 		s2 = out.strides[ 0 ];
 		s3 = out.strides[ 1 ];
 		for ( m = 0; m < nRows; m++ ) {
-			r = i[ m ] * s0;
+			r = o + i[m]*s0;
 			dr = m * s2;
 			for ( n = 0; n < nCols; n++ ) {
 				d[ dr + n*s3 ] = this.data[ r + j[n]*s1 ];

--- a/lib/mget.raw.js
+++ b/lib/mget.raw.js
@@ -20,21 +20,30 @@ function mget( rows, cols ) {
 	var nRows,
 		nCols,
 		out,
+		sgn,
 		d,
 		s0, s1, s2, s3,
+		o,
 		r, dr,
 		i, j, m, n;
 
+	s0 = this.strides[ 0 ];
+	s1 = this.strides[ 1 ];
+	o = this.offset;
+
 	if ( arguments.length < 2 ) {
 		i = rows;
-		j = i.length;
+		m = i.length;
 
 		// Create a row vector (matrix):
-		d = new BTYPES[ this.dtype ]( j );
-		out = new this.constructor( d, [1,j], this.dtype );
+		d = new BTYPES[ this.dtype ]( m );
+		out = new this.constructor( d, this.dtype, [1,m], 0, [m,1] );
 
-		for ( n = 0; n < j; n++ ) {
-			d[ n ] = this.data[ i[n] ];
+		sgn = ( s0 < 0 ) ? -1 : 1;
+		for ( n = 0; n < m; n++ ) {
+			j = i[ n ] % s0;
+			r = sgn * ( i[n] - j );
+			d[ n ] = this.data[ o + r + j*s1 ];
 		}
 	} else {
 		if ( rows === null ) {
@@ -60,14 +69,12 @@ function mget( rows, cols ) {
 		}
 
 		d = new BTYPES[ this.dtype ]( nRows*nCols );
-		out = new this.constructor( d, [nRows,nCols], this.dtype );
+		out = new this.constructor( d, this.dtype, [nRows,nCols], 0, [nCols,1] );
 
-		s0 = this.strides[ 0 ];
-		s1 = this.strides[ 1 ];
 		s2 = out.strides[ 0 ];
 		s3 = out.strides[ 1 ];
 		for ( m = 0; m < nRows; m++ ) {
-			r = i[ m ] * s0;
+			r = o + i[m]*s0;
 			dr = m * s2;
 			for ( n = 0; n < nCols; n++ ) {
 				d[ dr + n*s3 ] = this.data[ r + j[n]*s1 ];

--- a/lib/mset1.js
+++ b/lib/mset1.js
@@ -10,11 +10,18 @@
 * @param {Number} v - numeric value
 */
 function mset1( mat, idx, v ) {
-	var len = idx.length,
-		i;
+	var s0 = mat.strides[ 0 ],
+		s1 = mat.strides[ 1 ],
+		len = idx.length,
+		o = mat.offset,
+		sgn,
+		r, j, n;
 
-	for ( i = 0; i < len; i++ ) {
-		mat.data[ idx[ i ] ] = v;
+	sgn = ( s0 < 0 ) ? -1 : 1;
+	for ( n = 0; n < len; n++ ) {
+		j = idx[ n ] % s0;
+		r = sgn * ( idx[n] - j );
+		mat.data[ o + r + j*s1 ] = v;
 	}
 } // end FUNCTION mset1()
 

--- a/lib/mset2.js
+++ b/lib/mset2.js
@@ -11,19 +11,30 @@
 * @param {Object} ctx - `this` context when invoking the provided callback
 */
 function mset2( mat, idx, clbk, ctx ) {
-	var nRows = mat.shape[ 0 ],
+	var s0 = mat.strides[ 0 ],
+		s1 = mat.strides[ 1 ],
 		len = idx.length,
+		o = mat.offset,
+		sgn,
 		r, c,
-		i, j;
+		i, k, n;
 
-	for ( i = 0; i < len; i++ ) {
-		j = idx[ i ];
+	sgn = ( s0 < 0 ) ? -1 : 1;
+	for ( n = 0; n < len; n++ ) {
+		// Get the column number:
+		c = idx[ n ] % s0;
 
-		// Determine the row and column indices...
-		c = j % nRows; // remainder
-		r = ( j - c ) / nRows;
+		// Determine the row offset:
+		i = sgn * ( idx[n] - c );
 
-		mat.data[ j ] = clbk.call( ctx, mat.data[ j ], r, c, j );
+		// Get the row number:
+		r = i / s0;
+
+		// Calculate the index:
+		k = o + i + c*s1;
+
+		// Set the value:
+		mat.data[ k ] = clbk.call( ctx, mat.data[ k ], r, c, k );
 	}
 } // end FUNCTION mset2()
 

--- a/lib/mset3.js
+++ b/lib/mset3.js
@@ -10,14 +10,33 @@
 * @param {Matrix} m - Matrix instance
 */
 function mset3( mat, idx, m ) {
-	var len = idx.length,
-		i;
+	var s0 = mat.strides[ 0 ],
+		s1 = mat.strides[ 1 ],
+		s2 = m.strides[ 0 ],
+		s3 = m.strides[ 1 ],
+		len = idx.length,
+		o0 = mat.offset,
+		o1 = m.offset,
+		sgn0, sgn1,
+		r0, r1,
+		j0, j1,
+		n;
 
 	if ( m.length !== len ) {
 		throw new Error( 'mset()::invalid input argument. Number of indices does not match the number of elements in the value matrix.' );
 	}
-	for ( i = 0; i < len; i++ ) {
-		mat.data[ idx[ i ] ] = m.data[ i ];
+	sgn0 = ( s0 < 0 ) ? -1 : 1;
+	sgn1 = ( s2 < 0 ) ? -1 : 1;
+	for ( n = 0; n < len; n++ ) {
+		// Get the column number and row offset for the first matrix:
+		j0 = idx[ n ] % s0;
+		r0 = sgn0 * ( idx[n] - j0 );
+
+		// Get the column number and row offset for the value matrix:
+		j1 = n % s2;
+		r1 = sgn1 * ( n - j1 );
+
+		mat.data[ o0 + r0 + j0*s1 ] = m.data[ o1 + r1 + j1*s3  ];
 	}
 } // end FUNCTION mset3()
 

--- a/lib/mset4.js
+++ b/lib/mset4.js
@@ -12,20 +12,19 @@
 * @param {Object} ctx - `this` context when invoking the provided callback
 */
 function mset4( mat, rows, cols, clbk, ctx ) {
-	var nRows = rows.length,
+	var s0 = mat.strides[ 0 ],
+		s1 = mat.strides[ 1 ],
+		nRows = rows.length,
 		nCols = cols.length,
-		idx,
-		s0, s1,
+		o = mat.offset,
 		r,
-		i, j;
+		i, j, k;
 
-	s0 = mat.strides[ 0 ];
-	s1 = mat.strides[ 1 ];
 	for ( i = 0; i < nRows; i++ ) {
-		r = rows[ i ] * s0;
+		r = o + rows[i]*s0;
 		for ( j = 0; j < nCols; j++ ) {
-			idx = r + cols[j]*s1;
-			mat.data[ idx ] = clbk.call( ctx, mat.data[ idx ], rows[ i ], cols[ j ], idx );
+			k = r + cols[j]*s1;
+			mat.data[ k ] = clbk.call( ctx, mat.data[ k ], rows[ i ], cols[ j ], k );
 		}
 	}
 } // end FUNCTION mset4()

--- a/lib/mset5.js
+++ b/lib/mset5.js
@@ -11,16 +11,16 @@
 * @param {Number} v - numeric value
 */
 function mset5( mat, rows, cols, v ) {
-	var nRows = rows.length,
+	var s0 = mat.strides[ 0 ],
+		s1 = mat.strides[ 1 ],
+		nRows = rows.length,
 		nCols = cols.length,
-		s0, s1,
+		o = mat.offset,
 		r,
 		i, j;
 
-	s0 = mat.strides[ 0 ];
-	s1 = mat.strides[ 1 ];
 	for ( i = 0; i < nRows; i++ ) {
-		r = rows[ i ] * s0;
+		r = o + rows[i]*s0;
 		for ( j = 0; j < nCols; j++ ) {
 			mat.data[ r + cols[j]*s1 ] = v;
 		}

--- a/lib/mset6.js
+++ b/lib/mset6.js
@@ -11,24 +11,25 @@
 * @param {Matrix} m - Matrix instance
 */
 function mset6( mat, rows, cols, m ) {
-	var nRows = rows.length,
+	var s0 = mat.strides[ 0 ],
+		s1 = mat.strides[ 1 ],
+		s2 = m.strides[ 0 ],
+		s3 = m.strides[ 1 ],
+		nRows = rows.length,
 		nCols = cols.length,
-		s0, s1, s2, s3,
-		r, mr,
+		o0 = mat.offset,
+		o1 = m.offset,
+		r0, r1,
 		i, j;
 
 	if ( m.shape[ 0 ] !== nRows || m.shape[ 1 ] !== nCols ) {
 		throw new Error( 'mset()::invalid input argument. The dimensions given by the row and column indices do not match the value matrix dimensions.' );
 	}
-	s0 = mat.strides[ 0 ];
-	s1 = mat.strides[ 1 ];
-	s2 = m.strides[ 0 ];
-	s3 = m.strides[ 1 ];
 	for ( i = 0; i < nRows; i++ ) {
-		r = rows[ i ] * s0;
-		mr = i * s2;
+		r0 = o0 + rows[i]*s0;
+		r1 = o1 + i*s2;
 		for ( j = 0; j < nCols; j++ ) {
-			mat.data[ r + cols[j]*s1 ] = m.data[ mr + j*s3 ];
+			mat.data[ r0 + cols[j]*s1 ] = m.data[ r1 + j*s3 ];
 		}
 	}
 } // end FUNCTION mset6()

--- a/lib/set.js
+++ b/lib/set.js
@@ -25,7 +25,10 @@ function set( i, j, v ) {
 	if ( !isNumber( v ) ) {
 		throw new TypeError( 'set()::invalid input argument. An input value must be a number primitive. Value: `' + v + '`.' );
 	}
-	this.data[ i*this.strides[0] + j*this.strides[1] ] = v;
+	i = this.offset + i*this.strides[0] + j*this.strides[1];
+	if ( i >= 0 ) {
+		this.data[ i ] = v;
+	}
 	return this;
 } // end FUNCTION set()
 

--- a/lib/set.raw.js
+++ b/lib/set.raw.js
@@ -11,7 +11,10 @@
 */
 function set( i, j, v ) {
 	/* jshint validthis: true */
-	this.data[ i*this.strides[0] + j*this.strides[1] ] = v;
+	i = this.offset + i*this.strides[0] + j*this.strides[1];
+	if ( i >= 0 ) {
+		this.data[ i ] = v;
+	}
 	return this;
 } // end FUNCTION set()
 

--- a/lib/sget.js
+++ b/lib/sget.js
@@ -29,7 +29,8 @@ function sget( seq ) {
 		seqs,
 		mat,
 		len,
-		s0, s1, s2, s3,
+		s0, s1,
+		o,
 		d,
 		r, dr,
 		i, j;
@@ -49,18 +50,17 @@ function sget( seq ) {
 	len = nRows * nCols;
 
 	d = new BTYPES[ this.dtype ]( len );
-	mat = new this.constructor( d, [nRows,nCols], this.dtype );
+	mat = new this.constructor( d, this.dtype, [nRows,nCols], 0, [nCols,1] );
 
 	if ( len ) {
 		s0 = this.strides[ 0 ];
 		s1 = this.strides[ 1 ];
-		s2 = mat.strides[ 0 ];
-		s3 = mat.strides[ 1 ];
+		o = this.offset;
 		for ( i = 0; i < nRows; i++ ) {
-			r = rows[ i ] * s0;
-			dr = i * s2;
+			r = o + rows[i]*s0;
+			dr = i * nCols;
 			for ( j = 0; j < nCols; j++ ) {
-				d[ dr + j*s3 ] = this.data[ r + cols[j]*s1 ];
+				d[ dr + j ] = this.data[ r + cols[j]*s1 ];
 			}
 		}
 	}

--- a/lib/sget.raw.js
+++ b/lib/sget.raw.js
@@ -28,7 +28,8 @@ function sget( seq ) {
 		seqs,
 		mat,
 		len,
-		s0, s1, s2, s3,
+		s0, s1,
+		o,
 		d,
 		r, dr,
 		i, j;
@@ -42,18 +43,17 @@ function sget( seq ) {
 	len = nRows * nCols;
 
 	d = new BTYPES[ this.dtype ]( len );
-	mat = new this.constructor( d, [nRows,nCols], this.dtype );
+	mat = new this.constructor( d, this.dtype, [nRows,nCols], 0, [nCols,1] );
 
 	if ( len ) {
 		s0 = this.strides[ 0 ];
 		s1 = this.strides[ 1 ];
-		s2 = mat.strides[ 0 ];
-		s3 = mat.strides[ 1 ];
+		o = this.offset;
 		for ( i = 0; i < nRows; i++ ) {
-			r = rows[ i ] * s0;
-			dr = i * s2;
+			r = o + rows[i]*s0;
+			dr = i * nCols;
 			for ( j = 0; j < nCols; j++ ) {
-				d[ dr + j*s3 ] = this.data[ r + cols[j]*s1 ];
+				d[ dr + j ] = this.data[ r + cols[j]*s1 ];
 			}
 		}
 	}

--- a/lib/sset.js
+++ b/lib/sset.js
@@ -30,9 +30,9 @@ function sset( seq, val, thisArg ) {
 		mat,
 		ctx,
 		s0, s1, s2, s3,
-		idx,
-		r, mr,
-		i, j;
+		o0, o1,
+		r0, r1,
+		i, j, k;
 
 	if ( !isString( seq ) ) {
 		throw new TypeError( 'sset()::invalid input argument. Must provide a string primitive. Value: `' + seq + '`.' );
@@ -58,6 +58,7 @@ function sset( seq, val, thisArg ) {
 	}
 	s0 = this.strides[ 0 ];
 	s1 = this.strides[ 1 ];
+	o0 = this.offset;
 
 	// Callback...
 	if ( clbk ) {
@@ -67,10 +68,10 @@ function sset( seq, val, thisArg ) {
 			ctx = this;
 		}
 		for ( i = 0; i < nRows; i++ ) {
-			r = rows[ i ] * s0;
+			r0 = o0 + rows[i]*s0;
 			for ( j = 0; j < nCols; j++ ) {
-				idx = r + cols[j]*s1;
-				this.data[ idx ] = clbk.call( ctx, this.data[ idx ], rows[i], cols[j], idx );
+				k = r0 + cols[j]*s1;
+				this.data[ k ] = clbk.call( ctx, this.data[ k ], rows[i], cols[j], k );
 			}
 		}
 	}
@@ -84,20 +85,21 @@ function sset( seq, val, thisArg ) {
 		}
 		s2 = mat.strides[ 0 ];
 		s3 = mat.strides[ 1 ];
+		o1 = mat.offset;
 		for ( i = 0; i < nRows; i++ ) {
-			r = rows[ i ] * s0;
-			mr = i * s2;
+			r0 = o0 + rows[i]*s0;
+			r1 = o1 + i*s2;
 			for ( j = 0; j < nCols; j++ ) {
-				this.data[ r + cols[j]*s1 ] = mat.data[ mr + j*s3 ];
+				this.data[ r0 + cols[j]*s1 ] = mat.data[ r1 + j*s3 ];
 			}
 		}
 	}
 	// Single numeric value...
 	else {
 		for ( i = 0; i < nRows; i++ ) {
-			r = rows[ i ] * s0;
+			r0 = o0 + rows[i]*s0;
 			for ( j = 0; j < nCols; j++ ) {
-				this.data[ r + cols[j]*s1 ] = val;
+				this.data[ r0 + cols[j]*s1 ] = val;
 			}
 		}
 	}

--- a/lib/sset.raw.js
+++ b/lib/sset.raw.js
@@ -27,9 +27,9 @@ function sset( seq, val, thisArg ) {
 		mat,
 		ctx,
 		s0, s1, s2, s3,
-		idx,
-		r, mr,
-		i, j;
+		o0, o1,
+		r0, r1,
+		i, j, k;
 
 	seqs = seq.split( ',' );
 	if ( typeof val === 'function' ) {
@@ -49,6 +49,7 @@ function sset( seq, val, thisArg ) {
 	}
 	s0 = this.strides[ 0 ];
 	s1 = this.strides[ 1 ];
+	o0 = this.offset;
 
 	// Callback...
 	if ( clbk ) {
@@ -58,10 +59,10 @@ function sset( seq, val, thisArg ) {
 			ctx = this;
 		}
 		for ( i = 0; i < nRows; i++ ) {
-			r = rows[ i ] * s0;
+			r0 = o0 + rows[i]*s0;
 			for ( j = 0; j < nCols; j++ ) {
-				idx = r + cols[j]*s1;
-				this.data[ idx ] = clbk.call( ctx, this.data[ idx ], rows[i], cols[j], idx );
+				k = r0 + cols[j]*s1;
+				this.data[ k ] = clbk.call( ctx, this.data[ k ], rows[i], cols[j], k );
 			}
 		}
 	}
@@ -75,20 +76,21 @@ function sset( seq, val, thisArg ) {
 		}
 		s2 = mat.strides[ 0 ];
 		s3 = mat.strides[ 1 ];
+		o1 = mat.offset;
 		for ( i = 0; i < nRows; i++ ) {
-			r = rows[ i ] * s0;
-			mr = i * s2;
+			r0 = o0 + rows[i]*s0;
+			r1 = o1 + i*s2;
 			for ( j = 0; j < nCols; j++ ) {
-				this.data[ r + cols[j]*s1 ] = mat.data[ mr + j*s3 ];
+				this.data[ r0 + cols[j]*s1 ] = mat.data[ r1 + j*s3 ];
 			}
 		}
 	}
 	// Single numeric value...
 	else {
 		for ( i = 0; i < nRows; i++ ) {
-			r = rows[ i ] * s0;
+			r0 = o0 + rows[i]*s0;
 			for ( j = 0; j < nCols; j++ ) {
-				this.data[ r + cols[j]*s1 ] = val;
+				this.data[ r0 + cols[j]*s1 ] = val;
 			}
 		}
 	}

--- a/lib/toString.js
+++ b/lib/toString.js
@@ -15,13 +15,13 @@ function toString() {
 		m = nRows - 1,
 		n = nCols - 1,
 		str = '',
-		r,
+		o,
 		i, j;
 
 	for ( i = 0; i < nRows; i++ ) {
-		r = i * s0;
+		o = this.offset + i*s0;
 		for ( j = 0; j < nCols; j++ ) {
-			str += this.data[ r + j*s1 ];
+			str += this.data[ o + j*s1 ];
 			if ( j < n ) {
 				str += ',';
 			}

--- a/test/test.ctor.js
+++ b/test/test.ctor.js
@@ -20,14 +20,14 @@ var expect = chai.expect,
 
 describe( 'Matrix', function tests() {
 
-	var mat = ctor( new Float32Array( 10 ), [5,2], 'float32' );
+	var mat = ctor( new Float32Array( 10 ), 'float32', [5,2], 0, [2,1] );
 
 	it( 'should export a function', function test() {
 		expect( ctor ).to.be.a( 'function' );
 	});
 
-	it( 'should have an arity of 3', function test() {
-		assert.strictEqual( ctor.length, 3 );
+	it( 'should have an arity of 5', function test() {
+		assert.strictEqual( ctor.length, 5 );
 	});
 
 	it( 'should create a new Matrix instance', function test() {
@@ -37,8 +37,8 @@ describe( 'Matrix', function tests() {
 	it( 'should not require a `new` operator', function test() {
 		var A, B;
 
-		A = ctor( mat.data, mat.shape, mat.dtype );
-		B = new ctor( mat.data, mat.shape, mat.dtype );
+		A = ctor( mat.data, mat.shape, mat.dtype, mat.offset, mat.strides );
+		B = new ctor( mat.data, mat.shape, mat.dtype, mat.offset, mat.strides );
 
 		assert.isTrue( A instanceof ctor );
 
@@ -92,6 +92,12 @@ describe( 'Matrix', function tests() {
 		function foo() {
 			mat.strides = [ -4, 1 ];
 		}
+	});
+
+	it( 'should create a Matrix having an offset property', function test() {
+		assert.isTrue( mat.hasOwnProperty( 'offset' ) );
+		assert.isNumber( mat.offset );
+		assert.deepEqual( mat.offset, 0 );
 	});
 
 	it( 'should create a Matrix having a protected ndims property', function test() {

--- a/test/test.ctor.raw.js
+++ b/test/test.ctor.raw.js
@@ -20,14 +20,14 @@ var expect = chai.expect,
 
 describe( 'Matrix.raw', function tests() {
 
-	var mat = ctor( new Float32Array( 10 ), [5,2], 'float32' );
+	var mat = ctor( new Float32Array( 10 ), 'float32', [5,2], 0, [2,1] );
 
 	it( 'should export a function', function test() {
 		expect( ctor ).to.be.a( 'function' );
 	});
 
-	it( 'should have an arity of 3', function test() {
-		assert.strictEqual( ctor.length, 3 );
+	it( 'should have an arity of 5', function test() {
+		assert.strictEqual( ctor.length, 5 );
 	});
 
 	it( 'should create a new Matrix instance', function test() {
@@ -37,8 +37,8 @@ describe( 'Matrix.raw', function tests() {
 	it( 'should not require a `new` operator', function test() {
 		var A, B;
 
-		A = ctor( mat.data, mat.shape, mat.dtype );
-		B = new ctor( mat.data, mat.shape, mat.dtype );
+		A = ctor( mat.data, mat.shape, mat.dtype, mat.offset, mat.strides );
+		B = new ctor( mat.data, mat.shape, mat.dtype, mat.offset, mat.strides );
 
 		assert.isTrue( A instanceof ctor );
 
@@ -77,6 +77,12 @@ describe( 'Matrix.raw', function tests() {
 		assert.isTrue( mat.hasOwnProperty( 'strides' ) );
 		assert.isArray( mat.strides );
 		assert.deepEqual( mat.strides, [2,1] );
+	});
+
+	it( 'should create a Matrix having an offset property', function test() {
+		assert.isTrue( mat.hasOwnProperty( 'offset' ) );
+		assert.isNumber( mat.offset );
+		assert.deepEqual( mat.offset, 0 );
 	});
 
 	it( 'should create a Matrix having a ndims property', function test() {

--- a/test/test.get.js
+++ b/test/test.get.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix#get', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10], 'int8' );
+	});
 
 	it( 'should export a function', function test() {
 		expect( get ).to.be.a( 'function' );
@@ -90,6 +93,33 @@ describe( 'matrix#get', function tests() {
 		expected = 56;
 
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		actual = mat.get( 5, 6 );
+		expected = 53;
+
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		actual = mat.get( 5, 6 );
+		expected = 43;
+
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		actual = mat.get( 5, 6 );
+		expected = 46;
+
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should return undefined if provided an out-of-bounds index', function test() {

--- a/test/test.get.raw.js
+++ b/test/test.get.raw.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix.raw#get', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10], 'int8' );
+	});
 
 	it( 'should export a function', function test() {
 		expect( get ).to.be.a( 'function' );
@@ -42,6 +45,33 @@ describe( 'matrix.raw#get', function tests() {
 		expected = 56;
 
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		actual = mat.get( 5, 6 );
+		expected = 53;
+
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		actual = mat.get( 5, 6 );
+		expected = 43;
+
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		actual = mat.get( 5, 6 );
+		expected = 46;
+
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should return undefined if provided an out-of-bounds index', function test() {

--- a/test/test.iget.js
+++ b/test/test.iget.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix#iget', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i * 2;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10], 'int32' );
+	});
 
 	it( 'should export a function', function test() {
 		expect( iget ).to.be.a( 'function' );
@@ -65,6 +68,33 @@ describe( 'matrix#iget', function tests() {
 		expected = 112;
 
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		actual = mat.iget( 56 );
+		expected = 106;
+
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		actual = mat.iget( 56 );
+		expected = 86;
+
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		actual = mat.iget( 56 );
+		expected = 92;
+
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should accept negative indices', function test() {
@@ -74,6 +104,33 @@ describe( 'matrix#iget', function tests() {
 		expected = 196;
 
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		actual = mat.iget( -2 );
+		expected = 182;
+
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		actual = mat.iget( -2 );
+		expected = 2;
+
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		actual = mat.iget( -2 );
+		expected = 16;
+
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should return undefined if provided an out-of-bounds index', function test() {

--- a/test/test.iget.raw.js
+++ b/test/test.iget.raw.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix.raw#iget', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i * 2;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10], 'int32' );
+	});
 
 	it( 'should export a function', function test() {
 		expect( iget ).to.be.a( 'function' );
@@ -42,6 +45,33 @@ describe( 'matrix.raw#iget', function tests() {
 		expected = 112;
 
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		actual = mat.iget( 56 );
+		expected = 106;
+
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		actual = mat.iget( 56 );
+		expected = 86;
+
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		actual = mat.iget( 56 );
+		expected = 92;
+
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should accept negative indices', function test() {
@@ -51,6 +81,33 @@ describe( 'matrix.raw#iget', function tests() {
 		expected = 196;
 
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		actual = mat.iget( -2 );
+		expected = 182;
+
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		actual = mat.iget( -2 );
+		expected = 2;
+
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		actual = mat.iget( -2 );
+		expected = 16;
+
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should return undefined if provided an out-of-bounds index', function test() {

--- a/test/test.iset.js
+++ b/test/test.iset.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix#iset', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i * 2;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10], 'int32' );
+	});
 
 	it( 'should export a function', function test() {
 		expect( iset ).to.be.a( 'function' );
@@ -91,6 +94,45 @@ describe( 'matrix#iset', function tests() {
 
 		assert.notEqual( actual, prev );
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.iget( 56 );
+		mat.iset( 56, 499 );
+
+		actual = mat.iget( 56 );
+		expected = 499;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.iget( 56 );
+		mat.iset( 56, 1001 );
+
+		actual = mat.iget( 56 );
+		expected = 1001;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.iget( 56 );
+		mat.iset( 56, 782 );
+
+		actual = mat.iget( 56 );
+		expected = 782;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should accept negative indices', function test() {
@@ -104,6 +146,45 @@ describe( 'matrix#iset', function tests() {
 
 		assert.notEqual( actual, prev );
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.iget( -2 );
+		mat.iset( -2, 499 );
+
+		actual = mat.iget( -2 );
+		expected = 499;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.iget( -2 );
+		mat.iset( -2, 1001 );
+
+		actual = mat.iget( -2 );
+		expected = 1001;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.iget( -2 );
+		mat.iset( -2, 782 );
+
+		actual = mat.iget( -2 );
+		expected = 782;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should return the Matrix instance', function test() {

--- a/test/test.iset.raw.js
+++ b/test/test.iset.raw.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix.raw#iset', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i * 2;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10], 'int32' );
+	});
 
 	it( 'should export a function', function test() {
 		expect( iset ).to.be.a( 'function' );
@@ -46,6 +49,45 @@ describe( 'matrix.raw#iset', function tests() {
 
 		assert.notEqual( actual, prev );
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.iget( 56 );
+		mat.iset( 56, 499 );
+
+		actual = mat.iget( 56 );
+		expected = 499;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.iget( 56 );
+		mat.iset( 56, 1001 );
+
+		actual = mat.iget( 56 );
+		expected = 1001;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.iget( 56 );
+		mat.iset( 56, 782 );
+
+		actual = mat.iget( 56 );
+		expected = 782;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should accept negative indices', function test() {
@@ -59,6 +101,45 @@ describe( 'matrix.raw#iset', function tests() {
 
 		assert.notEqual( actual, prev );
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.iget( -2 );
+		mat.iset( -2, 499 );
+
+		actual = mat.iget( -2 );
+		expected = 499;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.iget( -2 );
+		mat.iset( -2, 1001 );
+
+		actual = mat.iget( -2 );
+		expected = 1001;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.iget( -2 );
+		mat.iset( -2, 782 );
+
+		actual = mat.iget( -2 );
+		expected = 782;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should return the Matrix instance', function test() {

--- a/test/test.mget.js
+++ b/test/test.mget.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix#mget', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10] );
+	});
 
 	it( 'should export a function', function test() {
 		expect( mget ).to.be.a( 'function' );
@@ -111,10 +114,40 @@ describe( 'matrix#mget', function tests() {
 	});
 
 	it( 'should return values located at specified linear indices', function test() {
-		var mat1 = mat.mget( [14,28,47] );
+		var m, expected;
 
-		assert.deepEqual( mat1.shape, [1,3] );
-		assert.strictEqual( mat1.toString(), '14,28,47' );
+		m = mat.mget( [14,28,47] );
+		expected = '14,28,47';
+
+		assert.deepEqual( m.shape, [1,3] );
+		assert.strictEqual( m.toString(), expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		m = mat.mget( [14,28,47] );
+		expected = '15,21,42';
+
+		assert.strictEqual( m.toString(), expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		m = mat.mget( [14,28,47] );
+		expected = '85,71,52';
+
+		assert.strictEqual( m.toString(), expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		m = mat.mget( [14,28,47] );
+		expected = '84,78,57';
+
+		assert.strictEqual( m.toString(), expected, 'flipud' );
 	});
 
 	it( 'should return values located at specified linear indices and ignore any indices which are out-of-bounds', function test() {
@@ -124,17 +157,77 @@ describe( 'matrix#mget', function tests() {
 	});
 
 	it( 'should return all rows and select columns', function test() {
-		var mat1 = mat.mget( null, [1] );
+		var m, expected;
 
-		assert.deepEqual( mat1.shape, [10,1] );
-		assert.strictEqual( mat1.toString(), '1;11;21;31;41;51;61;71;81;91' );
+		m = mat.mget( null, [1] );
+		expected = '1;11;21;31;41;51;61;71;81;91';
+
+		assert.deepEqual( m.shape, [10,1] );
+		assert.strictEqual( m.toString(), expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		m = mat.mget( null, [1] );
+		expected = '8;18;28;38;48;58;68;78;88;98';
+
+		assert.strictEqual( m.toString(), expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		m = mat.mget( null, [1] );
+		expected = '98;88;78;68;58;48;38;28;18;8';
+
+		assert.strictEqual( m.toString(), expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		m = mat.mget( null, [1] );
+		expected = '91;81;71;61;51;41;31;21;11;1';
+
+		assert.strictEqual( m.toString(), expected, 'flipud' );
 	});
 
 	it( 'should return all columns and select rows', function test() {
-		var mat1 = mat.mget( [1], null );
+		var m, expected;
 
-		assert.deepEqual( mat1.shape, [1,10] );
-		assert.strictEqual( mat1.toString(), '10,11,12,13,14,15,16,17,18,19' );
+		m = mat.mget( [1], null );
+		expected = '10,11,12,13,14,15,16,17,18,19';
+
+		assert.deepEqual( m.shape, [1,10] );
+		assert.strictEqual( m.toString(), expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		m = mat.mget( [1], null );
+		expected = '19,18,17,16,15,14,13,12,11,10';
+
+		assert.strictEqual( m.toString(), expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		m = mat.mget( [1], null );
+		expected = '89,88,87,86,85,84,83,82,81,80';
+
+		assert.strictEqual( m.toString(), expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		m = mat.mget( [1], null );
+		expected = '80,81,82,83,84,85,86,87,88,89';
+
+		assert.strictEqual( m.toString(), expected, 'flipud' );
 	});
 
 	it( 'should ignore out-of-bounds row and column indices', function test() {

--- a/test/test.mget.raw.js
+++ b/test/test.mget.raw.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,31 +29,124 @@ describe( 'matrix.raw#mget', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10], 'int8' );
+	});
 
 	it( 'should export a function', function test() {
 		expect( mget ).to.be.a( 'function' );
 	});
 
 	it( 'should return values located at specified linear indices', function test() {
-		var mat1 = mat.mget( [14,28,47] );
+		var m, expected;
 
-		assert.deepEqual( mat1.shape, [1,3] );
-		assert.strictEqual( mat1.toString(), '14,28,47' );
+		m = mat.mget( [14,28,47] );
+		expected = '14,28,47';
+
+		assert.deepEqual( m.shape, [1,3] );
+		assert.strictEqual( m.toString(), expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		m = mat.mget( [14,28,47] );
+		expected = '15,21,42';
+
+		assert.strictEqual( m.toString(), expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		m = mat.mget( [14,28,47] );
+		expected = '85,71,52';
+
+		assert.strictEqual( m.toString(), expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		m = mat.mget( [14,28,47] );
+		expected = '84,78,57';
+
+		assert.strictEqual( m.toString(), expected, 'flipud' );
 	});
 
 	it( 'should return all rows and select columns', function test() {
-		var mat1 = mat.mget( null, [1] );
+		var m, expected;
 
-		assert.deepEqual( mat1.shape, [10,1] );
-		assert.strictEqual( mat1.toString(), '1;11;21;31;41;51;61;71;81;91' );
+		m = mat.mget( null, [1] );
+		expected = '1;11;21;31;41;51;61;71;81;91';
+
+		assert.deepEqual( m.shape, [10,1] );
+		assert.strictEqual( m.toString(), expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		m = mat.mget( null, [1] );
+		expected = '8;18;28;38;48;58;68;78;88;98';
+
+		assert.strictEqual( m.toString(), expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		m = mat.mget( null, [1] );
+		expected = '98;88;78;68;58;48;38;28;18;8';
+
+		assert.strictEqual( m.toString(), expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		m = mat.mget( null, [1] );
+		expected = '91;81;71;61;51;41;31;21;11;1';
+
+		assert.strictEqual( m.toString(), expected, 'flipud' );
 	});
 
 	it( 'should return all columns and select rows', function test() {
-		var mat1 = mat.mget( [1], null );
+		var m, expected;
 
-		assert.deepEqual( mat1.shape, [1,10] );
-		assert.strictEqual( mat1.toString(), '10,11,12,13,14,15,16,17,18,19' );
+		m = mat.mget( [1], null );
+		expected = '10,11,12,13,14,15,16,17,18,19';
+
+		assert.deepEqual( m.shape, [1,10] );
+		assert.strictEqual( m.toString(), expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		m = mat.mget( [1], null );
+		expected = '19,18,17,16,15,14,13,12,11,10';
+
+		assert.strictEqual( m.toString(), expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		m = mat.mget( [1], null );
+		expected = '89,88,87,86,85,84,83,82,81,80';
+
+		assert.strictEqual( m.toString(), expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		m = mat.mget( [1], null );
+		expected = '80,81,82,83,84,85,86,87,88,89';
+
+		assert.strictEqual( m.toString(), expected, 'flipud' );
 	});
 
 	it( 'should not dedupe indices', function test() {

--- a/test/test.mset.js
+++ b/test/test.mset.js
@@ -219,36 +219,177 @@ describe( 'matrix#mset', function tests() {
 	});
 
 	it( 'should set Matrix values located at specified linear indices to a numeric value', function test() {
-		var submat;
+		var idx, m, prev, actual, expected;
 
-		mat.mset( [14,28,47], 999 );
-		submat = mat.mget( [14,28,47] );
+		idx = [ 14, 28, 47 ];
+		expected = '999,999,999';
 
-		assert.strictEqual( submat.toString(), '999,999,999' );
+		prev = mat.mget( idx );
+		mat.mset( idx, 999 );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, 999 );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, 999 );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.mget( idx );
+		mat.mset( idx, 999 );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should set Matrix values located at specified linear indices using a callback', function test() {
-		var submat;
+		var idx, m, prev, actual, expected;
 
-		mat.mset( [14,28,47], set );
-		submat = mat.mget( [14,28,47] );
+		idx = [ 14, 28, 47 ];
+		expected = '999,999,999';
 
-		assert.strictEqual( submat.toString(), '999,999,999' );
+		prev = mat.mget( idx );
+		mat.mset( idx, set );
 
-		function set( d, i, j, idx ) {
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'flipud' );
+
+		function set( d, i, j, k ) {
+			assert.isTrue( i >= 0 );
+			assert.isTrue( j >= 0 );
+			assert.isTrue( k >= 0 );
 			return 999;
 		}
 	});
 
 	it( 'should set Matrix values located at specified linear indices using a callback and a provided context', function test() {
-		var submat;
+		var idx, m, prev, actual, expected;
 
-		mat.mset( [14,28,47], set, null );
-		submat = mat.mget( [14,28,47] );
+		idx = [ 14, 28, 47 ];
+		expected = '999,999,999';
 
-		assert.strictEqual( submat.toString(), '999,999,999' );
+		prev = mat.mget( idx );
+		mat.mset( idx, set, null );
 
-		function set( d, i, j, idx ) {
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set, null );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set, null );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set, null );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'flipud' );
+
+		function set() {
 			/* jshint validthis:true */
 			assert.isNull( this );
 			return 999;
@@ -256,14 +397,34 @@ describe( 'matrix#mset', function tests() {
 	});
 
 	it( 'should set Matrix values located at specified linear indices to values from a different Matrix', function test() {
-		var submat, zeros;
+		var idx, m, vmat;
 
-		zeros = matrix( [1,3], 'int32' );
+		idx = [ 5, 53, 23 ];
 
-		mat.mset( [5,53,23], zeros );
-		submat = mat.mget( [5,53,23] );
+		vmat = matrix( new Int32Array( [1,2,3] ), [1,3], 'int32' );
 
-		assert.strictEqual( submat.toString(), '0,0,0' );
+		mat.mset( idx, vmat );
+		m = mat.mget( idx );
+
+		assert.strictEqual( m.toString(), '1,2,3' );
+
+		// Flip the value matrix top-to-bottom...
+		vmat.offset = vmat.length - vmat.strides[ 0 ];
+		vmat.strides[ 0 ] *= -1;
+
+		mat.mset( idx, vmat );
+		m = mat.mget( idx );
+
+		assert.strictEqual( m.toString(), '1,2,3', 'vmat flipud' );
+
+		// Flip the matrix top-to-bottom...
+		mat.offset = mat.length - mat.strides[ 0 ];
+		mat.strides[ 0 ] *= -1;
+
+		mat.mset( idx, vmat );
+		m = mat.mget( idx );
+
+		assert.strictEqual( m.toString(), '1,2,3', 'flipud' );
 	});
 
 	it( 'should set values located at specified linear indices and ignore any indices which are out-of-bounds', function test() {
@@ -307,6 +468,19 @@ describe( 'matrix#mset', function tests() {
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );
 
+		// Flip left-to-right...
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( null, [1] ).toString();
+		mat.mset( null, [1], 5 );
+
+		actual = mat.mget( null, [1] ).toString();
+		expected = '5;5;5;5;5;5;5;5;5;5';
+
+		assert.notEqual( prev, actual );
+		assert.strictEqual( actual, expected );
+
 		// Callback:
 		prev = mat.mget( null, [9] ).toString();
 		mat.mset( null, [9], set );
@@ -327,6 +501,19 @@ describe( 'matrix#mset', function tests() {
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );
 
+		// Flip top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( null, [8] ).toString();
+		mat.mset( null, [8], set );
+
+		actual = mat.mget( null, [8] ).toString();
+		expected = '20;20;20;20;20;20;20;20;20;20';
+
+		assert.notEqual( prev, actual );
+		assert.strictEqual( actual, expected );
+
 		// Matrix:
 		prev = mat.mget( null, [3] ).toString();
 		mat.mset( null, [3], matrix( [10,1], 'int32' ) );
@@ -337,7 +524,10 @@ describe( 'matrix#mset', function tests() {
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );
 
-		function set() {
+		function set( d, i, j, k ) {
+			assert.isTrue( i >= 0 );
+			assert.isTrue( j >= 0 );
+			assert.isTrue( k >= 0 );
 			return 20;
 		}
 	});
@@ -351,6 +541,19 @@ describe( 'matrix#mset', function tests() {
 
 		actual = mat.mget( [1], null ).toString();
 		expected = '5,5,5,5,5,5,5,5,5,5';
+
+		assert.notEqual( prev, actual );
+		assert.strictEqual( actual, expected );
+
+		// Flip left-to-right...
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( null, [1] ).toString();
+		mat.mset( null, [1], 5 );
+
+		actual = mat.mget( null, [1] ).toString();
+		expected = '5;5;5;5;5;5;5;5;5;5';
 
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );
@@ -371,6 +574,19 @@ describe( 'matrix#mset', function tests() {
 
 		actual = mat.mget( [2], null ).toString();
 		expected = '20,20,20,20,20,20,20,20,20,20';
+
+		assert.notEqual( prev, actual );
+		assert.strictEqual( actual, expected );
+
+		// Flip top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( null, [8] ).toString();
+		mat.mset( null, [8], set );
+
+		actual = mat.mget( null, [8] ).toString();
+		expected = '20;20;20;20;20;20;20;20;20;20';
 
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );

--- a/test/test.mset.raw.js
+++ b/test/test.mset.raw.js
@@ -30,7 +30,7 @@ describe( 'matrix.raw#mset', function tests() {
 		for ( var i = 0; i < data.length; i++ ) {
 			data[ i ] = i;
 		}
-		mat = matrix( data, [10,10] );
+		mat = matrix( data, [10,10], 'int32' );
 	});
 
 	it( 'should export a function', function test() {
@@ -56,36 +56,177 @@ describe( 'matrix.raw#mset', function tests() {
 	});
 
 	it( 'should set Matrix values located at specified linear indices to a numeric value', function test() {
-		var submat;
+		var idx, m, prev, actual, expected;
 
-		mat.mset( [14,28,47], 999 );
-		submat = mat.mget( [14,28,47] );
+		idx = [ 14, 28, 47 ];
+		expected = '999,999,999';
 
-		assert.strictEqual( submat.toString(), '999,999,999' );
+		prev = mat.mget( idx );
+		mat.mset( idx, 999 );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, 999 );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, 999 );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.mget( idx );
+		mat.mset( idx, 999 );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should set Matrix values located at specified linear indices using a callback', function test() {
-		var submat;
+		var idx, m, prev, actual, expected;
 
-		mat.mset( [14,28,47], set );
-		submat = mat.mget( [14,28,47] );
+		idx = [ 14, 28, 47 ];
+		expected = '999,999,999';
 
-		assert.strictEqual( submat.toString(), '999,999,999' );
+		prev = mat.mget( idx );
+		mat.mset( idx, set );
 
-		function set( d, i, j, idx ) {
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'flipud' );
+
+		function set( d, i, j, k ) {
+			assert.isTrue( i >= 0 );
+			assert.isTrue( j >= 0 );
+			assert.isTrue( k >= 0 );
 			return 999;
 		}
 	});
 
 	it( 'should set Matrix values located at specified linear indices using a callback and a provided context', function test() {
-		var submat;
+		var idx, m, prev, actual, expected;
 
-		mat.mset( [14,28,47], set, null );
-		submat = mat.mget( [14,28,47] );
+		idx = [ 14, 28, 47 ];
+		expected = '999,999,999';
 
-		assert.strictEqual( submat.toString(), '999,999,999' );
+		prev = mat.mget( idx );
+		mat.mset( idx, set, null );
 
-		function set( d, i, j, idx ) {
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set, null );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set, null );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.mget( idx );
+		mat.mset( idx, set, null );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected, 'flipud' );
+
+		function set() {
 			/* jshint validthis:true */
 			assert.isNull( this );
 			return 999;
@@ -93,20 +234,53 @@ describe( 'matrix.raw#mset', function tests() {
 	});
 
 	it( 'should set Matrix values located at specified linear indices to values from a different Matrix', function test() {
-		var submat, zeros;
+		var idx, m, vmat;
 
-		zeros = matrix( [1,3], 'int32' );
+		idx = [ 5, 53, 23 ];
 
-		mat.mset( [5,53,23], zeros );
-		submat = mat.mget( [5,53,23] );
+		vmat = matrix( new Int32Array( [1,2,3] ), [1,3], 'int32' );
 
-		assert.strictEqual( submat.toString(), '0,0,0' );
+		mat.mset( idx, vmat );
+		m = mat.mget( idx );
+
+		assert.strictEqual( m.toString(), '1,2,3' );
+
+		// Flip the value matrix top-to-bottom...
+		vmat.offset = vmat.length - vmat.strides[ 0 ];
+		vmat.strides[ 0 ] *= -1;
+
+		mat.mset( idx, vmat );
+		m = mat.mget( idx );
+
+		assert.strictEqual( m.toString(), '1,2,3', 'vmat flipud' );
+
+		// Flip the matrix top-to-bottom...
+		mat.offset = mat.length - mat.strides[ 0 ];
+		mat.strides[ 0 ] *= -1;
+
+		mat.mset( idx, vmat );
+		m = mat.mget( idx );
+
+		assert.strictEqual( m.toString(), '1,2,3', 'flipud' );
 	});
 
 	it( 'should set all rows and select columns', function test() {
 		var prev, actual, expected;
 
 		// Numeric value:
+		prev = mat.mget( null, [1] ).toString();
+		mat.mset( null, [1], 5 );
+
+		actual = mat.mget( null, [1] ).toString();
+		expected = '5;5;5;5;5;5;5;5;5;5';
+
+		assert.notEqual( prev, actual );
+		assert.strictEqual( actual, expected );
+
+		// Flip left-to-right...
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
 		prev = mat.mget( null, [1] ).toString();
 		mat.mset( null, [1], 5 );
 
@@ -136,6 +310,19 @@ describe( 'matrix.raw#mset', function tests() {
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );
 
+		// Flip top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( null, [8] ).toString();
+		mat.mset( null, [8], set );
+
+		actual = mat.mget( null, [8] ).toString();
+		expected = '20;20;20;20;20;20;20;20;20;20';
+
+		assert.notEqual( prev, actual );
+		assert.strictEqual( actual, expected );
+
 		// Matrix:
 		prev = mat.mget( null, [3] ).toString();
 		mat.mset( null, [3], matrix( [10,1], 'int32' ) );
@@ -146,7 +333,10 @@ describe( 'matrix.raw#mset', function tests() {
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );
 
-		function set() {
+		function set( d, i, j, k ) {
+			assert.isTrue( i >= 0 );
+			assert.isTrue( j >= 0 );
+			assert.isTrue( k >= 0 );
 			return 20;
 		}
 	});
@@ -160,6 +350,19 @@ describe( 'matrix.raw#mset', function tests() {
 
 		actual = mat.mget( [1], null ).toString();
 		expected = '5,5,5,5,5,5,5,5,5,5';
+
+		assert.notEqual( prev, actual );
+		assert.strictEqual( actual, expected );
+
+		// Flip left-to-right...
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.mget( null, [1] ).toString();
+		mat.mset( null, [1], 5 );
+
+		actual = mat.mget( null, [1] ).toString();
+		expected = '5;5;5;5;5;5;5;5;5;5';
 
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );
@@ -180,6 +383,19 @@ describe( 'matrix.raw#mset', function tests() {
 
 		actual = mat.mget( [2], null ).toString();
 		expected = '20,20,20,20,20,20,20,20,20,20';
+
+		assert.notEqual( prev, actual );
+		assert.strictEqual( actual, expected );
+
+		// Flip top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.mget( null, [8] ).toString();
+		mat.mset( null, [8], set );
+
+		actual = mat.mget( null, [8] ).toString();
+		expected = '20;20;20;20;20;20;20;20;20;20';
 
 		assert.notEqual( prev, actual );
 		assert.strictEqual( actual, expected );

--- a/test/test.set.js
+++ b/test/test.set.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix#set', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10] );
+	});
 
 	it( 'should export a function', function test() {
 		expect( set ).to.be.a( 'function' );
@@ -116,6 +119,45 @@ describe( 'matrix#set', function tests() {
 
 		assert.notEqual( actual, prev );
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.get( 5, 6 );
+		mat.set( 5, 6, 1001 );
+
+		actual = mat.get( 5, 6 );
+		expected = 1001;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.get( 5, 6 );
+		mat.set( 5, 6, 1002 );
+
+		actual = mat.get( 5, 6 );
+		expected = 1002;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.get( 5, 6 );
+		mat.set( 5, 6, 1003 );
+
+		actual = mat.get( 5, 6 );
+		expected = 1003;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should return the Matrix instance', function test() {
@@ -123,6 +165,10 @@ describe( 'matrix#set', function tests() {
 	});
 
 	it( 'should silently fail if provided an out-of-bounds index', function test() {
+		mat.set( 500, 100, 1000 );
+		assert.isUndefined( mat.get( 500, 100 ) );
+
+		mat.strides[ 0 ] *= -1;
 		mat.set( 500, 100, 1000 );
 		assert.isUndefined( mat.get( 500, 100 ) );
 	});

--- a/test/test.set.raw.js
+++ b/test/test.set.raw.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix.raw#set', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10], 'int32' );
+	});
 
 	it( 'should export a function', function test() {
 		expect( set ).to.be.a( 'function' );
@@ -46,6 +49,45 @@ describe( 'matrix.raw#set', function tests() {
 
 		assert.notEqual( actual, prev );
 		assert.strictEqual( actual, expected );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.strides[ 0 ] - 1;
+
+		prev = mat.get( 5, 6 );
+		mat.set( 5, 6, 1001 );
+
+		actual = mat.get( 5, 6 );
+		expected = 1001;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplr' );
+
+		// Flip the matrix top-to-bottom:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length - 1;
+
+		prev = mat.get( 5, 6 );
+		mat.set( 5, 6, 1002 );
+
+		actual = mat.get( 5, 6 );
+		expected = 1002;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'fliplrud' );
+
+		// Flip the matrix left-to-right:
+		mat.strides[ 1 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		prev = mat.get( 5, 6 );
+		mat.set( 5, 6, 1003 );
+
+		actual = mat.get( 5, 6 );
+		expected = 1003;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
 	it( 'should return the Matrix instance', function test() {
@@ -53,6 +95,10 @@ describe( 'matrix.raw#set', function tests() {
 	});
 
 	it( 'should silently fail if provided an out-of-bounds index', function test() {
+		mat.set( 500, 100, 1000 );
+		assert.isUndefined( mat.get( 500, 100 ) );
+
+		mat.strides[ 0 ] *= -1;
 		mat.set( 500, 100, 1000 );
 		assert.isUndefined( mat.get( 500, 100 ) );
 	});

--- a/test/test.sget.js
+++ b/test/test.sget.js
@@ -101,6 +101,15 @@ describe( 'matrix#sget', function tests() {
 
 		assert.deepEqual( mat1.shape, [2,2] );
 		assert.strictEqual( mat1.toString(), '13,12;23,22' );
+
+		// Flip the matrix instance up-down and then flip left-right:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length + mat.strides[0];
+
+		mat1 = mat.sget( '1:3,3:1:-1' );
+
+		assert.deepEqual( mat1.shape, [2,2] );
+		assert.strictEqual( mat1.toString(), '83,82;73,72' );
 	});
 
 	it( 'should return an empty matrix if a subsequence does not have any corresponding matrix elements', function test() {

--- a/test/test.sget.raw.js
+++ b/test/test.sget.raw.js
@@ -1,4 +1,4 @@
-/* global require, describe, it */
+/* global require, describe, it, beforeEach */
 'use strict';
 
 // MODULES //
@@ -29,7 +29,10 @@ describe( 'matrix.raw#sget', function tests() {
 	for ( var i = 0; i < data.length; i++ ) {
 		data[ i ] = i;
 	}
-	mat = matrix( data, [10,10] );
+
+	beforeEach( function before() {
+		mat = matrix( data, [10,10] );
+	});
 
 	it( 'should export a function', function test() {
 		expect( sget ).to.be.a( 'function' );
@@ -54,6 +57,15 @@ describe( 'matrix.raw#sget', function tests() {
 
 		assert.deepEqual( mat1.shape, [2,2] );
 		assert.strictEqual( mat1.toString(), '13,12;23,22' );
+
+		// Flip the matrix instance up-down and then flip left-right:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length + mat.strides[0];
+
+		mat1 = mat.sget( '1:3,3:1:-1' );
+
+		assert.deepEqual( mat1.shape, [2,2] );
+		assert.strictEqual( mat1.toString(), '83,82;73,72' );
 	});
 
 	it( 'should return an empty matrix if a subsequence does not have any corresponding matrix elements', function test() {

--- a/test/test.sset.js
+++ b/test/test.sset.js
@@ -129,7 +129,19 @@ describe( 'matrix#sset', function tests() {
 
 		assert.strictEqual( submat.toString(), '35,36,37,38;45,64,74,48;55,65,75,58;65,66,67,68' );
 
+		// Flip the matrix up-down:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		mat.sset( '4:6,6:8', set );
+		submat = mat.sget( '3:7,5:9' );
+
+		assert.strictEqual( submat.toString(), '65,66,67,68;55,64,74,58;45,65,75,48;35,36,37,38' );
+
 		function set( d, i, j, idx ) {
+			assert.isTrue( i >= 0 );
+			assert.isTrue( j >= 0 );
+			assert.isTrue( idx >= 0 );
 			return '' + j + i;
 		}
 	});
@@ -142,7 +154,7 @@ describe( 'matrix#sset', function tests() {
 
 		assert.strictEqual( submat.toString(), '35,36,37,38;45,64,74,48;55,65,75,58;65,66,67,68' );
 
-		function set( d, i, j, idx ) {
+		function set( d, i, j ) {
 			/* jshint validthis:true */
 			assert.isNull( this );
 			return '' + j + i;
@@ -156,17 +168,44 @@ describe( 'matrix#sset', function tests() {
 		submat = mat.sget( '3:7,5:9' );
 
 		assert.strictEqual( submat.toString(), '35,36,37,38;45,5,5,48;55,5,5,58;65,66,67,68' );
+
+		// Flip the matrix up-down:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		mat.sset( '4:6,6:8', 5 );
+		submat = mat.sget( '3:7,5:9' );
+
+		assert.strictEqual( submat.toString(), '65,66,67,68;55,5,5,58;45,5,5,48;35,36,37,38' );
 	});
 
 	it( 'should set Matrix elements to elements in a different Matrix', function test() {
-		var submat, zeros;
+		var submat, m;
 
-		zeros = matrix( [2,2], 'int8' );
+		m = matrix( new Int8Array( [1,2,3,4] ), [2,2], 'int8' );
 
-		mat.sset( '4:6,6:8', zeros );
+		mat.sset( '4:6,6:8', m );
 		submat = mat.sget( '3:7,5:9' );
 
-		assert.strictEqual( submat.toString(), '35,36,37,38;45,0,0,48;55,0,0,58;65,66,67,68' );
+		assert.strictEqual( submat.toString(), '35,36,37,38;45,1,2,48;55,3,4,58;65,66,67,68' );
+
+		// Flip the value matrix left-right:
+		m.strides[ 1 ] *= -1;
+		m.offset = m.strides[ 0 ] - 1;
+
+		mat.sset( '4:6,6:8', m );
+		submat = mat.sget( '3:7,5:9' );
+
+		assert.strictEqual( submat.toString(), '35,36,37,38;45,2,1,48;55,4,3,58;65,66,67,68' );
+
+		// Flip the matrix top-down:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		mat.sset( '4:6,6:8', m );
+		submat = mat.sget( '3:7,5:9' );
+
+		assert.strictEqual( submat.toString(), '65,66,67,68;55,2,1,58;45,4,3,48;35,36,37,38' );
 	});
 
 });

--- a/test/test.sset.raw.js
+++ b/test/test.sset.raw.js
@@ -82,7 +82,19 @@ describe( 'matrix.raw#sset', function tests() {
 
 		assert.strictEqual( submat.toString(), '35,36,37,38;45,64,74,48;55,65,75,58;65,66,67,68' );
 
+		// Flip the matrix up-down:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		mat.sset( '4:6,6:8', set );
+		submat = mat.sget( '3:7,5:9' );
+
+		assert.strictEqual( submat.toString(), '65,66,67,68;55,64,74,58;45,65,75,48;35,36,37,38' );
+
 		function set( d, i, j, idx ) {
+			assert.isTrue( i >= 0 );
+			assert.isTrue( j >= 0 );
+			assert.isTrue( idx >= 0 );
 			return '' + j + i;
 		}
 	});
@@ -95,7 +107,7 @@ describe( 'matrix.raw#sset', function tests() {
 
 		assert.strictEqual( submat.toString(), '35,36,37,38;45,64,74,48;55,65,75,58;65,66,67,68' );
 
-		function set( d, i, j, idx ) {
+		function set( d, i, j ) {
 			/* jshint validthis:true */
 			assert.isNull( this );
 			return '' + j + i;
@@ -109,17 +121,44 @@ describe( 'matrix.raw#sset', function tests() {
 		submat = mat.sget( '3:7,5:9' );
 
 		assert.strictEqual( submat.toString(), '35,36,37,38;45,5,5,48;55,5,5,58;65,66,67,68' );
+
+		// Flip the matrix up-down:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		mat.sset( '4:6,6:8', 5 );
+		submat = mat.sget( '3:7,5:9' );
+
+		assert.strictEqual( submat.toString(), '65,66,67,68;55,5,5,58;45,5,5,48;35,36,37,38' );
 	});
 
 	it( 'should set Matrix elements to elements in a different Matrix', function test() {
-		var submat, zeros;
+		var submat, m;
 
-		zeros = matrix( [2,2], 'int8' );
+		m = matrix( new Int8Array( [1,2,3,4] ), [2,2], 'int8' );
 
-		mat.sset( '4:6,6:8', zeros );
+		mat.sset( '4:6,6:8', m );
 		submat = mat.sget( '3:7,5:9' );
 
-		assert.strictEqual( submat.toString(), '35,36,37,38;45,0,0,48;55,0,0,58;65,66,67,68' );
+		assert.strictEqual( submat.toString(), '35,36,37,38;45,1,2,48;55,3,4,58;65,66,67,68' );
+
+		// Flip the value matrix left-right:
+		m.strides[ 1 ] *= -1;
+		m.offset = m.strides[ 0 ] - 1;
+
+		mat.sset( '4:6,6:8', m );
+		submat = mat.sget( '3:7,5:9' );
+
+		assert.strictEqual( submat.toString(), '35,36,37,38;45,2,1,48;55,4,3,58;65,66,67,68' );
+
+		// Flip the matrix top-down:
+		mat.strides[ 0 ] *= -1;
+		mat.offset = mat.length + mat.strides[ 0 ];
+
+		mat.sset( '4:6,6:8', m );
+		submat = mat.sget( '3:7,5:9' );
+
+		assert.strictEqual( submat.toString(), '65,66,67,68;55,2,1,58;45,4,3,48;35,36,37,38' );
 	});
 
 });


### PR DESCRIPTION
Breaking changes, as APIs have changed. The instances now expose an `offset` property to allow creating strided views onto the same data store; e.g., when flipping a matrix from left-to-right. To accommodate this change, the constructor now has a different signature, accepting both `offset` and `strides` arguments. All internal methods have been updated in accordance with this signature.

Tests have been written to address various matrix views of the same data store (fliplr, flipud, fliplr+flipud). Additionally, where values from a different matrix are set, the means to index into these stores takes into account view access.