### PR TITLE
Fixes NaN bug, update error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 
+# Files #
+#########
+
+
 # Directories #
 ###############
 reports/
@@ -12,6 +16,28 @@ build/
 *.exe
 *.o
 *.so
+*.slo
+*.lo
+*.obj
+*.dylib
+*.dll
+*.lai
+*.la
+*.a
+*.lib
+*.ko
+*.elf
+
+# Precompiled headers #
+#######################
+*.gch
+*.pch
+
+# Executables #
+###############
+*.exe
+*.out
+*.app
 
 # Packages #
 ############
@@ -51,12 +77,65 @@ Desktop.ini
 # Node.js #
 ###########
 /node_modules/
+pids
+*.pid
+*.seed
 
 # Matlab #
 ##########
-
-# Windows default autosave extension
 *.asv
-
-# Compiled MEX binaries (all platforms)
 *.mex*
+
+# Fortran #
+###########
+*.mod
+
+# R #
+#####
+.Rhistory
+.Rapp.history
+.Rproj.user/
+
+# TeX #
+#######
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.dvi
+*-converted-to.*
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.brf
+*.run.xml
+*.fdb_latexmk
+*.synctex
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+*.alg
+*.loa
+acs-*.bib
+*.thm
+*.nav
+*.snm
+*.vrb
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.brf
+*-concordance.tex
+*.tikz
+*-tikzDictionary
+*.idx
+*.ilg
+*.ind
+*.ist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
 node_js:
+  - '5'
+  - '4'
   - '0.12'
-  - '0.11'
   - '0.10'
-  - '0.8'
   - 'iojs'
 before_install:
   - npm update -g npm
 after_script:
-  - npm run coveralls
+  - npm run codecov
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ else
 	OPEN ?= xdg-open
 endif
 
+
 # NOTES #
 
 NOTES ?= 'TODO|FIXME|WARNING|HACK|NOTE'
@@ -38,7 +39,7 @@ ISTANBUL_HTML_REPORT_PATH ?= $(ISTANBUL_OUT)/lcov-report/index.html
 # JSHINT #
 
 JSHINT ?= ./node_modules/.bin/jshint
-JSHINT_REPORTER ?= ./node_modules/jshint-stylish/stylish.js
+JSHINT_REPORTER ?= ./node_modules/jshint-stylish
 
 
 
@@ -123,7 +124,7 @@ lint-jshint: node_modules
 
 # NODE #
 
-# Installing node_modules:
+# Install node_modules:
 .PHONY: install
 
 install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Matrix
 ===
-[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Dependencies][dependencies-image]][dependencies-url]
+[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coverage Status][codecov-image]][codecov-url] [![Dependencies][dependencies-image]][dependencies-url]
 
 > Matrices.
 
@@ -249,7 +249,7 @@ __Note__: out-of-bounds row and column indices will silently fail.
 <a name="matrix-iset"></a>
 #### Matrix.prototype.iset( index, value )
 
-Sets a `Matrix` element located at a specified [`index`](#linear-indexing). If `index < 0`, the index refers to a position relative to the `Matrix` length, where `index = -1` corresponds to the last element. 
+Sets a `Matrix` element located at a specified [`index`](#linear-indexing). If `index < 0`, the index refers to a position relative to the `Matrix` length, where `index = -1` corresponds to the last element.
 
 ``` javascript
 mat.iset( 7, 25 );
@@ -409,7 +409,7 @@ A callback is provided four arguments:
 *	__j__: column index
 *	__idx__: linear index
 
-and is __expected__ to return a `number` primitive or a value which can be cast to a `number` primitive. 
+and is __expected__ to return a `number` primitive or a value which can be cast to a `number` primitive.
 
 ``` javascript
 function set( d, i, j, idx ) {
@@ -481,7 +481,7 @@ __Note__: out-of-bounds row and column indices will return a value of `undefined
 <a name="matrix-iget"></a>
 #### Matrix.prototype.iget( index )
 
-Returns a `Matrix` element located at a specified [`index`](#linear-indexing). If `index < 0`, the index refers to a position relative to the `Matrix` length, where `index = -1` corresponds to the last element. 
+Returns a `Matrix` element located at a specified [`index`](#linear-indexing). If `index < 0`, the index refers to a position relative to the `Matrix` length, where `index = -1` corresponds to the last element.
 
 ``` javascript
 var value = mat.iget( 7 );
@@ -569,7 +569,7 @@ submatrix = mat.sget( ':,:' ); // Copy a matrix
 /*
 	[ 0 1
 	  2 3
-	  4 5 
+	  4 5
 	  6 7
 	  8 9 ]
 */
@@ -643,7 +643,7 @@ for ( i = 0; i < rows.length; i++ ) {
 	rows[ i ] = new Array( cols.length );
 	for ( j = 0; j < cols.length; j++ ) {
 		rows[ i ][ j ] = parseFloat( cols[ j ] );
-	}	
+	}
 }
 ```
 
@@ -724,7 +724,7 @@ __Notes__:
 *	Specifying a `dtype` does __not__ cast the data to a different storage type. Instead, providing the argument circumvents the need to determine the input `data` type, resulting in increased performance.
 *	Input `data` __must__ be a typed array. Unlike the higher-level `Matrix` interface, plain `arrays` are __not__ cast to `float64`. Providing a plain `array` can lead to subtle bugs and affect performance.
 *	`Matrix` properties and methods are the same as for the higher-level API, with the exception that `Matrix` properties are __no__ longer read-only and methods do __not__ perform input argument validation.
-* 	Setting properties is __not__ recommended as the `Matrix` can become corrupted; e.g., incompatible dimensions, out-of-bounds indexing, etc. In contrast to the strict API above, setting `Matrix` properties will __not__ result in an `error` being thrown. Accordingly, property modification may introduce silent bugs. 
+* 	Setting properties is __not__ recommended as the `Matrix` can become corrupted; e.g., incompatible dimensions, out-of-bounds indexing, etc. In contrast to the strict API above, setting `Matrix` properties will __not__ result in an `error` being thrown. Accordingly, property modification may introduce silent bugs.
 *	The lower-level `Matrix` constructor has the same interface as the higher-level `Matrix` constructor.
 
 
@@ -825,8 +825,8 @@ Copyright &copy; 2015. The [Compute.io](https://github.com/compute-io) Authors.
 [travis-image]: http://img.shields.io/travis/dstructs/matrix/master.svg
 [travis-url]: https://travis-ci.org/dstructs/matrix
 
-[coveralls-image]: https://img.shields.io/coveralls/dstructs/matrix/master.svg
-[coveralls-url]: https://coveralls.io/r/dstructs/matrix?branch=master
+[codecov-image]: https://img.shields.io/c/github/codecov/dstructs/matrix/master.svg
+[codecov-url]: https://codecov.io/github/dstructs/matrix?branch=master
 
 [dependencies-image]: http://img.shields.io/david/dstructs/matrix.svg
 [dependencies-url]: https://david-dm.org/dstructs/matrix

--- a/lib/get.js
+++ b/lib/get.js
@@ -18,7 +18,7 @@ var isNonNegativeInteger = require( 'validate.io-nonnegative-integer' );
 function get( i, j ) {
 	/*jshint validthis:true */
 	if ( !isNonNegativeInteger( i ) || !isNonNegativeInteger( j ) ) {
-		throw new TypeError( 'get()::invalid input argument. Indices must be nonnegative integers. Values: `[' + i + ','+ j + ']`.' );
+		throw new TypeError( 'invalid input argument. Indices must be nonnegative integers. Values: `[' + i + ','+ j + ']`.' );
 	}
 	return this.data[ this.offset + i*this.strides[0] + j*this.strides[1] ];
 } // end FUNCTION get()

--- a/lib/iget.js
+++ b/lib/iget.js
@@ -18,7 +18,7 @@ function iget( idx ) {
 	/*jshint validthis:true */
 	var r, j;
 	if ( !isInteger( idx ) ) {
-		throw new TypeError( 'iget()::invalid input argument. Must provide a integer. Value: `' + idx + '`.' );
+		throw new TypeError( 'invalid input argument. Must provide a integer. Value: `' + idx + '`.' );
 	}
 	if ( idx < 0 ) {
 		idx += this.length;

--- a/lib/iset.js
+++ b/lib/iset.js
@@ -20,10 +20,10 @@ function iset( idx, v ) {
 	/* jshint validthis: true */
 	var r, j;
 	if ( !isInteger( idx ) ) {
-		throw new TypeError( 'iset()::invalid input argument. An index must be an integer. Value: `' + idx + '`.' );
+		throw new TypeError( 'invalid input argument. An index must be an integer. Value: `' + idx + '`.' );
 	}
 	if ( !isNumber( v ) ) {
-		throw new TypeError( 'iset()::invalid input argument. An input value must be a number primitive. Value: `' + v + '`.' );
+		throw new TypeError( 'invalid input argument. An input value must be a number primitive. Value: `' + v + '`.' );
 	}
 	if ( idx < 0 ) {
 		idx += this.length;

--- a/lib/iset.js
+++ b/lib/iset.js
@@ -3,6 +3,7 @@
 // MODULES //
 
 var isInteger = require( 'validate.io-integer-primitive' ),
+	isnan = require( 'validate.io-nan' ),
 	isNumber = require( 'validate.io-number-primitive' );
 
 
@@ -22,7 +23,7 @@ function iset( idx, v ) {
 	if ( !isInteger( idx ) ) {
 		throw new TypeError( 'invalid input argument. An index must be an integer. Value: `' + idx + '`.' );
 	}
-	if ( !isNumber( v ) ) {
+	if ( !isNumber( v ) && !isnan( v ) ) {
 		throw new TypeError( 'invalid input argument. An input value must be a number primitive. Value: `' + v + '`.' );
 	}
 	if ( idx < 0 ) {

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -64,16 +64,16 @@ function matrix() {
 
 	// Input argument validation...
 	if ( !isNonNegativeIntegerArray( shape ) ) {
-		throw new TypeError( 'matrix()::invalid input argument. A matrix shape must be an array of nonnegative integers. Value: `' + shape + '`.' );
+		throw new TypeError( 'invalid input argument. A matrix shape must be an array of nonnegative integers. Value: `' + shape + '`.' );
 	}
 	ndims = shape.length;
 	if ( ndims !== 2 ) {
-		throw new Error( 'matrix()::invalid input argument. Shape must be a 2-element array. Value: `' + shape + '`.' );
+		throw new Error( 'invalid input argument. Shape must be a 2-element array. Value: `' + shape + '`.' );
 	}
 	// If a `dtype` has been provided, validate...
 	if ( vFLG === 123 || vFLG === 23 ) {
 		if ( !contains( DTYPES, dtype ) ) {
-			throw new TypeError( 'matrix()::invalid input argument. Unrecognized/unsupported data type. Value: `' + dtype + '`.' );
+			throw new TypeError( 'invalid input argument. Unrecognized/unsupported data type. Value: `' + dtype + '`.' );
 		}
 	} else {
 		dtype = 'float64';
@@ -86,10 +86,10 @@ function matrix() {
 	if ( vFLG === 123 || vFLG === 12 ) {
 		dt = getType( data );
 		if ( !contains( DTYPES, dt ) && !isArray( data ) ) {
-			throw new TypeError( 'matrix()::invalid input argument. Input data must be a valid type. Consult the documentation for a list of valid data types. Value: `' + data + '`.' );
+			throw new TypeError( 'invalid input argument. Input data must be a valid type. Consult the documentation for a list of valid data types. Value: `' + data + '`.' );
 		}
 		if ( len !== data.length ) {
-			throw new Error( 'matrix()::invalid input argument. Matrix shape does not match the input data length.' );
+			throw new Error( 'invalid input argument. Matrix shape does not match the input data length.' );
 		}
 		// Only cast if either 1) both a `data` and `dtype` argument have been provided and they do not agree or 2) when provided a plain Array...
 		if ( ( vFLG === 123 && dt !== dtype ) || dt === 'generic' ) {

--- a/lib/matrix.raw.js
+++ b/lib/matrix.raw.js
@@ -53,7 +53,7 @@ function matrix() {
 	}
 	ndims = shape.length;
 	if ( ndims !== 2 ) {
-		throw new Error( 'matrix()::invalid input argument. Shape must be a 2-element array. Value: `' + shape + '`.' );
+		throw new Error( 'invalid input argument. Shape must be a 2-element array. Value: `' + shape + '`.' );
 	}
 	len = 1;
 	for ( i = 0; i < ndims; i++ ) {
@@ -63,11 +63,11 @@ function matrix() {
 		if ( !dtype ) {
 			dtype = getType( data );
 			if ( !contains( DTYPES, dtype ) ) {
-				throw new TypeError( 'matrix()::invalid input argument. Input data must be a valid type. Consult the documentation for a list of valid data types. Value: `' + data + '`.' );
+				throw new TypeError( 'invalid input argument. Input data must be a valid type. Consult the documentation for a list of valid data types. Value: `' + data + '`.' );
 			}
 		}
 		if ( len !== data.length ) {
-			throw new Error( 'matrix()::invalid input argument. Matrix shape does not match the input data length.' );
+			throw new Error( 'invalid input argument. Matrix shape does not match the input data length.' );
 		}
 	} else {
 		// Initialize a zero-filled typed array...

--- a/lib/mget.js
+++ b/lib/mget.js
@@ -38,7 +38,7 @@ function mget( rows, cols ) {
 
 	if ( arguments.length < 2 ) {
 		if ( !isNonNegativeIntegerArray( rows ) ) {
-			throw new TypeError( 'mget()::invalid input argument. Linear indices must be specified as a nonnegative integer array. Value: `' + rows + '`.' );
+			throw new TypeError( 'invalid input argument. Linear indices must be specified as a nonnegative integer array. Value: `' + rows + '`.' );
 		}
 		// Filter the input indices to ensure within bounds...
 		i = [];
@@ -76,7 +76,7 @@ function mget( rows, cols ) {
 			}
 		}
 		else {
-			throw new TypeError( 'mget()::invalid input argument. Row indices must be specified as a nonnegative integer array. Value: `' + rows + '`.' );
+			throw new TypeError( 'invalid input argument. Row indices must be specified as a nonnegative integer array. Value: `' + rows + '`.' );
 		}
 
 		nCols = this.shape[ 1 ];
@@ -95,7 +95,7 @@ function mget( rows, cols ) {
 			}
 		}
 		else {
-			throw new TypeError( 'mget()::invalid input argument. Column indices must be specified as a nonnegative integer array. Value: `' + cols + '`.' );
+			throw new TypeError( 'invalid input argument. Column indices must be specified as a nonnegative integer array. Value: `' + cols + '`.' );
 		}
 		nRows = i.length;
 		nCols = j.length;

--- a/lib/mset.js
+++ b/lib/mset.js
@@ -43,7 +43,7 @@ function getIndices( idx, len ) {
 		}
 	}
 	else {
-		throw new TypeError( 'mset()::invalid input argument. Row and column indices must be arrays of nonnegative integers. Value: `' + idx + '`.' );
+		throw new TypeError( 'invalid input argument. Row and column indices must be arrays of nonnegative integers. Value: `' + idx + '`.' );
 	}
 	return out;
 } // end FUNCTION getIndices()
@@ -76,7 +76,7 @@ function mset() {
 	// 2 input arguments...
 	if ( nargs < 3 ) {
 		if ( !isNonNegativeIntegerArray( args[ 0 ] ) ) {
-			throw new TypeError( 'mset()::invalid input argument. First argument must be an array of nonnegative integers. Value: `' + args[ 0 ] + '`.' );
+			throw new TypeError( 'invalid input argument. First argument must be an array of nonnegative integers. Value: `' + args[ 0 ] + '`.' );
 		}
 		// indices, clbk
 		if ( isFunction( args[ 1 ] ) ) {
@@ -97,7 +97,7 @@ function mset() {
 		// indices, clbk, context
 		if ( isFunction( args[ 1 ] ) ) {
 			if ( !isNonNegativeIntegerArray( args[ 0 ] ) ) {
-				throw new TypeError( 'mset()::invalid input argument. First argument must be an array of nonnegative integers. Value: `' + args[ 0 ] + '`.' );
+				throw new TypeError( 'invalid input argument. First argument must be an array of nonnegative integers. Value: `' + args[ 0 ] + '`.' );
 			}
 			mset2( this, args[ 0 ], args[ 1 ], args[ 2 ] );
 		}
@@ -126,7 +126,7 @@ function mset() {
 	else {
 		// rows, cols, function, context
 		if ( !isFunction( args[ 2 ] ) ) {
-			throw new TypeError( 'mset()::invalid input argument. Callback argument must be a function. Value: `' + args[ 2 ] + '`.' );
+			throw new TypeError( 'invalid input argument. Callback argument must be a function. Value: `' + args[ 2 ] + '`.' );
 		}
 		rows = getIndices( args[ 0 ], this.shape[ 0 ] );
 		cols = getIndices( args[ 1 ], this.shape[ 1 ] );

--- a/lib/mset.js
+++ b/lib/mset.js
@@ -3,6 +3,7 @@
 // MODULES //
 
 var isFunction = require( 'validate.io-function' ),
+	isnan = require( 'validate.io-nan' ),
 	isNumber = require( 'validate.io-number-primitive' ),
 	isNonNegativeIntegerArray = require( 'validate.io-nonnegative-integer-array' );
 
@@ -83,7 +84,7 @@ function mset() {
 			mset2( this, args[ 0 ], args[ 1 ] );
 		}
 		// indices, number
-		else if ( isNumber( args[ 1 ] ) ) {
+		else if ( isNumber( args[ 1 ] ) || isnan( args[ 1 ] ) ) {
 			mset1( this, args[ 0 ], args[ 1 ] );
 		}
 		// indices, matrix

--- a/lib/mset3.js
+++ b/lib/mset3.js
@@ -23,7 +23,7 @@ function mset3( mat, idx, m ) {
 		n;
 
 	if ( m.length !== len ) {
-		throw new Error( 'mset()::invalid input argument. Number of indices does not match the number of elements in the value matrix.' );
+		throw new Error( 'invalid input argument. Number of indices does not match the number of elements in the value matrix.' );
 	}
 	sgn0 = ( s0 < 0 ) ? -1 : 1;
 	sgn1 = ( s2 < 0 ) ? -1 : 1;

--- a/lib/mset6.js
+++ b/lib/mset6.js
@@ -23,7 +23,7 @@ function mset6( mat, rows, cols, m ) {
 		i, j;
 
 	if ( m.shape[ 0 ] !== nRows || m.shape[ 1 ] !== nCols ) {
-		throw new Error( 'mset()::invalid input argument. The dimensions given by the row and column indices do not match the value matrix dimensions.' );
+		throw new Error( 'invalid input argument. The dimensions given by the row and column indices do not match the value matrix dimensions.' );
 	}
 	for ( i = 0; i < nRows; i++ ) {
 		r0 = o0 + rows[i]*s0;

--- a/lib/set.js
+++ b/lib/set.js
@@ -3,6 +3,7 @@
 // MODULES //
 
 var isNonNegativeInteger = require( 'validate.io-nonnegative-integer' ),
+	isnan = require( 'validate.io-nan' ),
 	isNumber = require( 'validate.io-number-primitive' );
 
 
@@ -22,7 +23,7 @@ function set( i, j, v ) {
 	if ( !isNonNegativeInteger( i ) || !isNonNegativeInteger( j ) ) {
 		throw new TypeError( 'invalid input argument. Row and column indices must be nonnegative integers. Values: `[' + i + ',' + j + ']`.' );
 	}
-	if ( !isNumber( v ) ) {
+	if ( !isNumber( v ) && !isnan( v ) ) {
 		throw new TypeError( 'invalid input argument. An input value must be a number primitive. Value: `' + v + '`.' );
 	}
 	i = this.offset + i*this.strides[0] + j*this.strides[1];

--- a/lib/set.js
+++ b/lib/set.js
@@ -20,10 +20,10 @@ var isNonNegativeInteger = require( 'validate.io-nonnegative-integer' ),
 function set( i, j, v ) {
 	/* jshint validthis: true */
 	if ( !isNonNegativeInteger( i ) || !isNonNegativeInteger( j ) ) {
-		throw new TypeError( 'set()::invalid input argument. Row and column indices must be nonnegative integers. Values: `[' + i + ',' + j + ']`.' );
+		throw new TypeError( 'invalid input argument. Row and column indices must be nonnegative integers. Values: `[' + i + ',' + j + ']`.' );
 	}
 	if ( !isNumber( v ) ) {
-		throw new TypeError( 'set()::invalid input argument. An input value must be a number primitive. Value: `' + v + '`.' );
+		throw new TypeError( 'invalid input argument. An input value must be a number primitive. Value: `' + v + '`.' );
 	}
 	i = this.offset + i*this.strides[0] + j*this.strides[1];
 	if ( i >= 0 ) {

--- a/lib/sget.js
+++ b/lib/sget.js
@@ -36,11 +36,11 @@ function sget( seq ) {
 		i, j;
 
 	if ( !isString( seq ) ) {
-		throw new TypeError( 'sget()::invalid input argument. Must provide a string primitive. Value: `' + seq + '`.' );
+		throw new TypeError( 'invalid input argument. Must provide a string primitive. Value: `' + seq + '`.' );
 	}
 	seqs = seq.split( ',' );
 	if ( seqs.length !== 2 ) {
-		throw new Error( 'sget()::invalid input argument. Subsequence string must specify row and column subsequences. Value: `' + seq + '`.' );
+		throw new Error( 'invalid input argument. Subsequence string must specify row and column subsequences. Value: `' + seq + '`.' );
 	}
 	rows = ispace( seqs[ 0 ], this.shape[ 0 ] );
 	cols = ispace( seqs[ 1 ], this.shape[ 1 ] );

--- a/lib/sset.js
+++ b/lib/sset.js
@@ -35,11 +35,11 @@ function sset( seq, val, thisArg ) {
 		i, j, k;
 
 	if ( !isString( seq ) ) {
-		throw new TypeError( 'sset()::invalid input argument. Must provide a string primitive. Value: `' + seq + '`.' );
+		throw new TypeError( 'invalid input argument. Must provide a string primitive. Value: `' + seq + '`.' );
 	}
 	seqs = seq.split( ',' );
 	if ( seqs.length !== 2 ) {
-		throw new Error( 'sset()::invalid input argument. Subsequence string must specify row and column subsequences. Value: `' + seq + '`.' );
+		throw new Error( 'invalid input argument. Subsequence string must specify row and column subsequences. Value: `' + seq + '`.' );
 	}
 	if ( isFunction( val ) ) {
 		clbk = val;

--- a/lib/sset.js
+++ b/lib/sset.js
@@ -78,10 +78,10 @@ function sset( seq, val, thisArg ) {
 	// Input matrix...
 	else if ( mat ) {
 		if ( nRows !== mat.shape[ 0 ] ) {
-			throw new Error( 'sset()::invalid input arguments. Row subsequence does not match input matrix dimensions. Expected a [' + nRows + ',' + nCols + '] matrix and instead received a [' + mat.shape.join( ',' ) + '] matrix.' );
+			throw new Error( 'invalid input arguments. Row subsequence does not match input matrix dimensions. Expected a [' + nRows + ',' + nCols + '] matrix and instead received a [' + mat.shape.join( ',' ) + '] matrix.' );
 		}
 		if ( nCols !== mat.shape[ 1 ] ) {
-			throw new Error( 'sset()::invalid input arguments. Column subsequence does not match input matrix dimensions. Expected a [' + nRows + ',' + nCols + '] matrix and instead received a [' + mat.shape.join( ',' ) + '] matrix.' );
+			throw new Error( 'invalid input arguments. Column subsequence does not match input matrix dimensions. Expected a [' + nRows + ',' + nCols + '] matrix and instead received a [' + mat.shape.join( ',' ) + '] matrix.' );
 		}
 		s2 = mat.strides[ 0 ];
 		s3 = mat.strides[ 1 ];

--- a/lib/sset.raw.js
+++ b/lib/sset.raw.js
@@ -69,10 +69,10 @@ function sset( seq, val, thisArg ) {
 	// Input matrix...
 	else if ( mat ) {
 		if ( nRows !== mat.shape[ 0 ] ) {
-			throw new Error( 'sset()::invalid input arguments. Row subsequence does not match input matrix dimensions. Expected a [' + nRows + ',' + nCols + '] matrix and instead received a [' + mat.shape.join( ',' ) + '] matrix.' );
+			throw new Error( 'invalid input arguments. Row subsequence does not match input matrix dimensions. Expected a [' + nRows + ',' + nCols + '] matrix and instead received a [' + mat.shape.join( ',' ) + '] matrix.' );
 		}
 		if ( nCols !== mat.shape[ 1 ] ) {
-			throw new Error( 'sset()::invalid input arguments. Column subsequence does not match input matrix dimensions. Expected a [' + nRows + ',' + nCols + '] matrix and instead received a [' + mat.shape.join( ',' ) + '] matrix.' );
+			throw new Error( 'invalid input arguments. Column subsequence does not match input matrix dimensions. Expected a [' + nRows + ',' + nCols + '] matrix and instead received a [' + mat.shape.join( ',' ) + '] matrix.' );
 		}
 		s2 = mat.strides[ 0 ];
 		s3 = mat.strides[ 1 ];

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "jshint": "2.x.x",
     "jshint-stylish": "2.x.x",
     "mocha": "2.x.x",
-    "type-name": "^1.0.1"
+    "type-name": "^1.0.1",
+    "validate.io-typed-array": "^1.0.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     }
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha",
-    "test-cov": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --dir ./reports/coverage -- -R spec",
-    "coveralls": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --dir ./reports/coveralls/coverage --report lcovonly -- -R spec && cat ./reports/coveralls/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./reports/coveralls"
+    "test": "mocha",
+    "test-cov": "istanbul cover ./node_modules/.bin/_mocha --dir ./reports/coverage -- -R spec",
+    "codecov": "istanbul cover ./node_modules/.bin/_mocha --dir ./reports/codecov/coverage --report lcovonly -- -R spec && cat ./reports/codecov/coverage/lcov.info | codecov && rm -rf ./reports/codecov"
   },
   "main": "./lib",
   "repository": {
@@ -63,11 +63,11 @@
     "validate.io-string-primitive": "^1.0.0"
   },
   "devDependencies": {
-    "chai": "2.x.x",
-    "coveralls": "^2.11.1",
+    "chai": "3.x.x",
+    "codecov": "^1.0.1",
     "istanbul": "^0.3.0",
     "jshint": "2.x.x",
-    "jshint-stylish": "^1.0.0",
+    "jshint-stylish": "2.x.x",
     "mocha": "2.x.x",
     "type-name": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     {
       "name": "Athan Reines",
       "email": "kgryte@gmail.com"
+    },
+    {
+      "name": "Philipp Burckhardt",
+      "email": "pburckhardt@outlook.com"
     }
   ],
   "scripts": {
@@ -52,6 +56,7 @@
     "validate.io-contains": "^1.0.0",
     "validate.io-function": "^1.0.2",
     "validate.io-integer-primitive": "^1.0.0",
+    "validate.io-nan": "^1.0.3",
     "validate.io-nonnegative-integer": "^1.0.0",
     "validate.io-nonnegative-integer-array": "^1.0.1",
     "validate.io-number-primitive": "^1.0.0",

--- a/test/test.btypes.js
+++ b/test/test.btypes.js
@@ -3,10 +3,7 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Module to be tested:
+var chai = require( 'chai' ),
 	BTYPES = require( './../lib/btypes.js' );
 
 

--- a/test/test.ctor.js
+++ b/test/test.ctor.js
@@ -6,6 +6,9 @@
 var // Expectation library:
 	chai = require( 'chai' ),
 
+	// Validates whether a value is a typed array:
+	isTypedArray = require( 'validate.io-typed-array' ),
+
 	// Module to be tested:
 	ctor = require( './../lib/ctor.js' );
 
@@ -134,7 +137,7 @@ describe( 'Matrix', function tests() {
 
 	it( 'should create a Matrix having a protected data property', function test() {
 		assert.isTrue( mat.hasOwnProperty( 'data' ) );
-		assert.isObject( mat.data );
+		assert.isTrue( isTypedArray( mat.data ) );
 
 		expect( foo ).to.throw( Error );
 		function foo() {

--- a/test/test.ctor.js
+++ b/test/test.ctor.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Validates whether a value is a typed array:
+var chai = require( 'chai' ),
 	isTypedArray = require( 'validate.io-typed-array' ),
-
-	// Module to be tested:
 	ctor = require( './../lib/ctor.js' );
 
 

--- a/test/test.ctor.raw.js
+++ b/test/test.ctor.raw.js
@@ -6,6 +6,9 @@
 var // Expectation library:
 	chai = require( 'chai' ),
 
+	// Validates whether a value is a typed array:
+	isTypedArray = require( 'validate.io-typed-array' ),
+
 	// Module to be tested:
 	ctor = require( './../lib/ctor.raw.js' );
 
@@ -104,7 +107,7 @@ describe( 'Matrix.raw', function tests() {
 
 	it( 'should create a Matrix having a data property', function test() {
 		assert.isTrue( mat.hasOwnProperty( 'data' ) );
-		assert.isObject( mat.data );
+		assert.isTrue( isTypedArray( mat.data ) );
 	});
 
 });

--- a/test/test.ctor.raw.js
+++ b/test/test.ctor.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Validates whether a value is a typed array:
+var chai = require( 'chai' ),
 	isTypedArray = require( 'validate.io-typed-array' ),
-
-	// Module to be tested:
 	ctor = require( './../lib/ctor.raw.js' );
 
 

--- a/test/test.dtypes.js
+++ b/test/test.dtypes.js
@@ -3,10 +3,7 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Module to be tested:
+var chai = require( 'chai' ),
 	DTYPES = require( './../lib/dtypes.js' );
 
 

--- a/test/test.get.js
+++ b/test/test.get.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Module to be tested:
 	get = require( './../lib/get.js' );
 
 

--- a/test/test.get.raw.js
+++ b/test/test.get.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ).raw,
-
-	// Module to be tested:
 	get = require( './../lib/get.raw.js' );
 
 

--- a/test/test.iget.js
+++ b/test/test.iget.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Module to be tested:
 	iget = require( './../lib/iget.js' );
 
 

--- a/test/test.iget.raw.js
+++ b/test/test.iget.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ).raw,
-
-	// Module to be tested:
 	iget = require( './../lib/iget.raw.js' );
 
 

--- a/test/test.iset.js
+++ b/test/test.iset.js
@@ -64,7 +64,6 @@ describe( 'matrix#iset', function tests() {
 	it( 'should throw an error if provided a non-numeric value to set', function test() {
 		var values = [
 			'5',
-			NaN,
 			null,
 			true,
 			undefined,

--- a/test/test.iset.js
+++ b/test/test.iset.js
@@ -3,16 +3,9 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Validates whether a value is equal to NaN
 	isnan = require( 'validate.io-nan' ),
-
-	// Module to be tested:
 	iset = require( './../lib/iset.js' );
 
 

--- a/test/test.iset.js
+++ b/test/test.iset.js
@@ -9,6 +9,9 @@ var // Expectation library:
 	// Matrix class:
 	matrix = require( './../lib' ),
 
+	// Validates whether a value is equal to NaN
+	isnan = require( 'validate.io-nan' ),
+
 	// Module to be tested:
 	iset = require( './../lib/iset.js' );
 
@@ -132,6 +135,32 @@ describe( 'matrix#iset', function tests() {
 
 		assert.notEqual( actual, prev );
 		assert.strictEqual( actual, expected, 'flipud' );
+	});
+
+	it( 'should set a Matrix element to NaN', function test() {
+		var mat1, mat2,
+			prev, actual, expected;
+
+		mat1 = matrix( [1,2,3,4], [2,2], 'float32' );
+		prev = mat1.iget( 2 );
+		mat1.iset( 2, NaN );
+
+		actual = mat1.iget( 2 );
+
+		assert.notEqual( actual, prev );
+		assert.isTrue( isnan( actual ) );
+
+		// For integer matrices, NaN will be cast to 0:
+		mat2 = matrix( [1,2,3,4], [2,2], 'int32' );
+		prev = mat2.iget( 2 );
+		mat2.iset( 2, NaN );
+
+		actual = mat2.iget( 2 );
+		expected = 0;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected );
+
 	});
 
 	it( 'should accept negative indices', function test() {

--- a/test/test.iset.raw.js
+++ b/test/test.iset.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ).raw,
-
-	// Module to be tested:
 	iset = require( './../lib/iset.raw.js' );
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,10 +3,7 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Module to be tested:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' );
 
 

--- a/test/test.matrix.js
+++ b/test/test.matrix.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Determine a value's type name:
+var chai = require( 'chai' ),
 	typeName = require( 'type-name' ),
-
-	// Module to be tested:
 	matrix = require( './../lib/matrix.js' );
 
 

--- a/test/test.matrix.raw.js
+++ b/test/test.matrix.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Determine a value's type name:
+var chai = require( 'chai' ),
 	typeName = require( 'type-name' ),
-
-	// Module to be tested:
 	matrix = require( './../lib/matrix.raw.js' );
 
 

--- a/test/test.mget.js
+++ b/test/test.mget.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Module to be tested:
 	mget = require( './../lib/mget.js' );
 
 

--- a/test/test.mget.raw.js
+++ b/test/test.mget.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ).raw,
-
-	// Module to be tested:
 	mget = require( './../lib/mget.raw.js' );
 
 

--- a/test/test.mset.js
+++ b/test/test.mset.js
@@ -273,6 +273,41 @@ describe( 'matrix#mset', function tests() {
 		assert.strictEqual( actual, expected, 'flipud' );
 	});
 
+	it( 'should set Matrix values located at specified linear indices to NaN', function test() {
+		var idx, mat, m, prev, actual, expected;
+
+		mat = matrix( [1,2,3,4,5,6,7,8,9], [3,3], 'float64' );
+
+		idx = [ 2, 5, 8 ];
+		expected = 'NaN,NaN,NaN';
+
+		prev = mat.mget( idx );
+		mat.mset( idx, NaN );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected );
+
+		// For integer-typed matrices, elements are set to 0:
+
+		mat = matrix( [1,2,3,4,5,6,7,8,9], [3,3], 'int32' );
+
+		idx = [ 2, 5, 8 ];
+		expected = '0,0,0';
+
+		prev = mat.mget( idx );
+		mat.mset( idx, NaN );
+
+		m = mat.mget( idx );
+		actual = m.toString();
+
+		assert.notEqual( actual, prev.toString() );
+		assert.strictEqual( actual, expected );
+
+	});
+
 	it( 'should set Matrix values located at specified linear indices using a callback', function test() {
 		var idx, m, prev, actual, expected;
 

--- a/test/test.mset.js
+++ b/test/test.mset.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Module to be tested:
 	mset = require( './../lib/mset.js' );
 
 
@@ -291,7 +286,6 @@ describe( 'matrix#mset', function tests() {
 		assert.strictEqual( actual, expected );
 
 		// For integer-typed matrices, elements are set to 0:
-
 		mat = matrix( [1,2,3,4,5,6,7,8,9], [3,3], 'int32' );
 
 		idx = [ 2, 5, 8 ];

--- a/test/test.mset.raw.js
+++ b/test/test.mset.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ).raw,
-
-	// Module to be tested:
 	mset = require( './../lib/mset.raw.js' );
 
 

--- a/test/test.set.js
+++ b/test/test.set.js
@@ -89,7 +89,6 @@ describe( 'matrix#set', function tests() {
 	it( 'should throw an error if provided a non-numeric value to set', function test() {
 		var values = [
 			'5',
-			NaN,
 			null,
 			true,
 			undefined,

--- a/test/test.set.js
+++ b/test/test.set.js
@@ -3,16 +3,9 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Validates whether a value is equal to NaN
 	isnan = require( 'validate.io-nan' ),
-
-	// Module to be tested:
 	set = require( './../lib/set.js' );
 
 

--- a/test/test.set.js
+++ b/test/test.set.js
@@ -9,6 +9,9 @@ var // Expectation library:
 	// Matrix class:
 	matrix = require( './../lib' ),
 
+	// Validates whether a value is equal to NaN
+	isnan = require( 'validate.io-nan' ),
+
 	// Module to be tested:
 	set = require( './../lib/set.js' );
 
@@ -157,6 +160,32 @@ describe( 'matrix#set', function tests() {
 
 		assert.notEqual( actual, prev );
 		assert.strictEqual( actual, expected, 'flipud' );
+	});
+
+	it( 'should set a Matrix element to NaN', function test() {
+		var mat1, mat2,
+			prev, actual, expected;
+
+		mat1 = matrix( [1,2,3,4], [2,2], 'float32' );
+		prev = mat1.get( 1, 1 );
+		mat1.set( 1, 1, NaN );
+
+		actual = mat1.get( 1, 1 );
+
+		assert.notEqual( actual, prev );
+		assert.isTrue( isnan( actual ) );
+
+		// For integer matrices, NaN will be casted to 0:
+		mat2 = matrix( [1,2,3,4], [2,2], 'int32' );
+		prev = mat2.get( 1, 1 );
+		mat2.set( 1, 1, NaN );
+
+		actual = mat2.get( 1, 1 );
+		expected = 0;
+
+		assert.notEqual( actual, prev );
+		assert.strictEqual( actual, expected );
+
 	});
 
 	it( 'should return the Matrix instance', function test() {

--- a/test/test.set.raw.js
+++ b/test/test.set.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ).raw,
-
-	// Module to be tested:
 	set = require( './../lib/set.raw.js' );
 
 

--- a/test/test.sget.js
+++ b/test/test.sget.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Module to be tested:
 	sget = require( './../lib/sget.js' );
 
 

--- a/test/test.sget.raw.js
+++ b/test/test.sget.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ).raw,
-
-	// Module to be tested:
 	sget = require( './../lib/sget.raw.js' );
 
 

--- a/test/test.sset.js
+++ b/test/test.sset.js
@@ -179,6 +179,18 @@ describe( 'matrix#sset', function tests() {
 		assert.strictEqual( submat.toString(), '65,66,67,68;55,5,5,58;45,5,5,48;35,36,37,38' );
 	});
 
+	it( 'should set Matrix elements to NaN', function test() {
+		var mat;
+
+		mat = matrix( [1,2,3,4,5,6,7,8,9], [3,3], 'float64' );
+
+		assert.strictEqual( mat.toString(), '1,2,3;4,5,6;7,8,9' );
+
+		mat.sset( '0:2,0:2', NaN );
+
+		assert.strictEqual( mat.toString(), 'NaN,NaN,3;NaN,NaN,6;7,8,9' );
+	});
+
 	it( 'should set Matrix elements to elements in a different Matrix', function test() {
 		var submat, m;
 

--- a/test/test.sset.js
+++ b/test/test.sset.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Module to be tested:
 	sset = require( './../lib/sset.js' );
 
 

--- a/test/test.sset.raw.js
+++ b/test/test.sset.raw.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ).raw,
-
-	// Module to be tested:
 	sset = require( './../lib/sset.raw.js' );
 
 

--- a/test/test.toString.js
+++ b/test/test.toString.js
@@ -3,13 +3,8 @@
 
 // MODULES //
 
-var // Expectation library:
-	chai = require( 'chai' ),
-
-	// Matrix class:
+var chai = require( 'chai' ),
 	matrix = require( './../lib' ),
-
-	// Module to be tested:
 	toString = require( './../lib/toString.js' );
 
 


### PR DESCRIPTION
- Resolves issue #3. For integer-typed arrays, when setting an element to `NaN` it will be cast to `0`. This is the standard behavior we also have for typed arrays, so I would think we should not handle floating-point matrices differently.
- Updates error messages to not include `name()::` as a prefix anymore, with `name` being a placeholder for the name of the function