### PR TITLE
Resolve #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ var mat = matrix( data, [1,10] );
     [ 0 0 0 0 0 0 0 0 0 0 ]
 */
 
-var value = mat.get( 3, 1 );
+var value = mat.get( 1, 3 );
 // returns 0
 
 value = mat[ 3 ];

--- a/README.md
+++ b/README.md
@@ -218,8 +218,10 @@ __Note__: while a `Matrix` has a `length` property, a `Matrix` should __not__ be
 ``` javascript
 var data = new Float32Array( 10 );
 
-var mat = matrix( data, [10,1] );
-// [ 0 0 0 0 0 0 0 0 0 0 ]
+var mat = matrix( data, [1,10] );
+/*
+    [ 0 0 0 0 0 0 0 0 0 0 ]
+*/
 
 var value = mat.get( 3, 1 );
 // returns 0

--- a/lib/tojson.js
+++ b/lib/tojson.js
@@ -1,5 +1,13 @@
 'use strict';
 
+// MODULES //
+
+var cast = require( 'dstructs-cast-arrays' ),
+	copy = require( 'utils-copy' );
+
+
+// TOJSON //
+
 /**
 * FUNCTION: toJSON()
 *	Returns a JSON representation of a Matrix.
@@ -9,29 +17,21 @@
 function toJSON() {
 	/* jshint validthis: true */
 	var prop,
-		out,
-		len,
-		d,
-		i;
+		out;
 
-	// Copy data to a generic array...
-	len = this.data.length;
-	d = new Array( len );
-	for ( i = 0; i < len; i++ ) {
-		d[ i ] = this.data[ i ];
-	}
 	// Build an object containing all Matrix properties needed to revive a serialized Matrix...
 	out = {};
 	out.type = 'Matrix';
 	out.dtype = this.dtype;
-	out.shape = this.shape;
+	out.shape = copy( this.shape );
 	out.offset = this.offset;
-	out.strides = this.strides;
+	out.strides = copy( this.strides );
 
 	prop = Object.getOwnPropertyDescriptor( this, 'data' );
 	out.raw = prop.writable && prop.configurable && prop.enumerable;
 
-	out.data = d;
+	// Cast data to a generic array:
+	out.data = cast( this.data, 'generic' );
 
 	return out;
 } // end FUNCTION toJSON()

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "compute-dtype": "^1.0.0",
     "compute-indexspace": "^1.0.1",
     "dstructs-cast-arrays": "^1.0.2",
+    "utils-copy": "^1.0.0",
     "validate.io-array": "^1.0.6",
     "validate.io-contains": "^1.0.0",
     "validate.io-function": "^1.0.2",

--- a/test/test.tojson.js
+++ b/test/test.tojson.js
@@ -122,4 +122,19 @@ describe( 'matrix#toJSON', function tests() {
 		assert.deepEqual( actual, expected );
 	});
 
+	it( 'should deep copy properties to prevent accidental mutation', function test() {
+		var mat, json;
+
+		mat = matrix( [4,4], 'int8' );
+		json = mat.toJSON();
+
+		assert.deepEqual( mat.dtype, json.dtype );
+		assert.deepEqual( mat.shape, json. shape );
+		assert.deepEqual( mat.offset, json.offset );
+		assert.deepEqual( mat.strides, json.strides );
+
+		assert.isTrue( mat.shape !== json.shape );
+		assert.isTrue( mat.strides !== json.strides );
+	});
+
 });


### PR DESCRIPTION
This PR will
* update `toJSON` to use the [dstructs-cast-arrays](https://github.com/dstructs/cast-arrays) module to cast the underlying data to a generic `array`
* update `toJSON` to [deep copy](https://github.com/kgryte/utils-copy) `shape` and `strides` properties to prevent side-effects
* fix README example where a column matrix was generated, but a row matrix was displayed, by converting the example to use a row matrix

Resolves #11.